### PR TITLE
Preserve group_ids when loading datasets from the HF mirror

### DIFF
--- a/src/raman_bench/benchmark.py
+++ b/src/raman_bench/benchmark.py
@@ -57,6 +57,12 @@ def _is_float_col(s: str) -> bool:
         return False
 
 
+# Column written by raman_data's mirror export to carry replicate structure
+# (see raman_data/scripts/mirror_to_huggingface.py and
+# RamanDataset.to_dataframe). It is neither a wavenumber nor a target.
+GROUP_ID_COL = "_group_id"
+
+
 def configure_benchmark(config, init_benchmark: bool = True) -> "RamanBenchmark":
     """Instantiate a :class:`RamanBenchmark` from a loaded config dict.
 
@@ -409,14 +415,16 @@ class RamanBenchmark:
             logger.warning("Failed to read parquet for %s: %s", dataset_name, e)
             return None
 
-        # Separate wavenumber columns (float-parseable) from target columns
+        # Separate wavenumber columns (float-parseable) from target columns.
+        # The group-id column is metadata: it must not be mistaken for a target.
         all_cols = df.columns.tolist()
         shift_cols = sorted([c for c in all_cols if _is_float_col(c)], key=float)
-        target_cols = [c for c in all_cols if not _is_float_col(c)]
+        target_cols = [c for c in all_cols if not _is_float_col(c) and c != GROUP_ID_COL]
 
         # Extract arrays
         spectra = df[shift_cols].values.astype(np.float32)
         raman_shifts = np.array([float(c) for c in shift_cols])
+        group_ids = df[GROUP_ID_COL].to_numpy() if GROUP_ID_COL in all_cols else None
 
         # Try to load metadata from separate metadata.json file
         target_names = None
@@ -478,6 +486,7 @@ class RamanBenchmark:
             raman_shifts=raman_shifts,
             target_names=target_names,
             info=info,
+            group_ids=group_ids,
         )
 
     # ------------------------------------------------------------------

--- a/tests/test_mirror_group_ids.py
+++ b/tests/test_mirror_group_ids.py
@@ -1,0 +1,81 @@
+"""Tests that the HF mirror's group-id column survives loading.
+
+``raman_data``'s mirror export writes replicate structure into a ``_group_id``
+column. ``_load_from_mirror`` classified every non-float-parseable column as a
+target, so ``_group_id`` was silently treated as one: it never reached
+``RamanDataset``, and on a single-target dataset it also made ``targets``
+two-dimensional.
+"""
+
+import pandas as pd
+import pytest
+
+from raman_bench import benchmark as bench_mod
+from raman_bench.benchmark import GROUP_ID_COL, RamanBenchmark, _is_float_col
+
+
+def _mirror_df(with_group_id: bool):
+    """Two wavenumber columns, one target, optionally a group id."""
+    data = {
+        "400.0": [1.0, 2.0, 3.0, 4.0],
+        "401.5": [5.0, 6.0, 7.0, 8.0],
+    }
+    if with_group_id:
+        data[GROUP_ID_COL] = [0, 0, 1, 1]
+    data["target"] = [0, 0, 1, 1]
+    return pd.DataFrame(data)
+
+
+def _bench():
+    """A RamanBenchmark stub carrying only what the mirror loader reads."""
+    b = RamanBenchmark.__new__(RamanBenchmark)
+    b.mirror_repo = "dummy/repo"
+    b.cache_dir_raw = ".cache"
+    return b
+
+
+@pytest.fixture
+def stub_mirror(monkeypatch):
+    """Serve a fabricated parquet; make metadata.json unavailable."""
+
+    def _apply(df):
+        def fake_download(repo_id, filename, repo_type, cache_dir):
+            if filename.endswith("metadata.json"):
+                raise FileNotFoundError("no metadata in this stub")
+            return "unused.parquet"
+
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", fake_download, raising=False)
+        monkeypatch.setattr(bench_mod.pd, "read_parquet", lambda _: df)
+
+    return _apply
+
+
+def test_group_id_is_not_treated_as_a_target(stub_mirror):
+    stub_mirror(_mirror_df(with_group_id=True))
+    ds = _bench()._load_from_mirror("stub_dataset")
+
+    assert ds is not None
+    assert ds.target_names == ["target"]
+    assert ds.targets.ndim == 1
+
+
+def test_group_ids_reach_the_dataset(stub_mirror):
+    stub_mirror(_mirror_df(with_group_id=True))
+    ds = _bench()._load_from_mirror("stub_dataset")
+
+    assert ds.group_ids is not None
+    assert ds.group_ids.tolist() == [0, 0, 1, 1]
+    assert ds.spectra.shape == (4, 2)
+
+
+def test_absent_group_id_column_is_fine(stub_mirror):
+    stub_mirror(_mirror_df(with_group_id=False))
+    ds = _bench()._load_from_mirror("stub_dataset")
+
+    assert ds.group_ids is None
+    assert ds.target_names == ["target"]
+
+
+def test_group_id_col_is_not_wavenumber_parseable():
+    """Guards the assumption the filter rests on."""
+    assert not _is_float_col(GROUP_ID_COL)


### PR DESCRIPTION
`raman_data`'s mirror export writes replicate structure into a `_group_id`
column (`scripts/mirror_to_huggingface.py`), but `_load_from_mirror`
classifies every non-float-parseable column as a target:

```python
target_cols = [c for c in all_cols if not _is_float_col(c)]
```

so `_group_id` lands in `target_cols` and never reaches `RamanDataset`. On a
single-target dataset it also makes `len(target_cols) == 2`, so `targets`
becomes 2-D and the task-type inference reads the wrong column.

This affects `locust_phase_hemolymph` today — currently the only dataset
carrying explicit `group_ids`.

**Changes**
- `GROUP_ID_COL` constant, excluded from `target_cols`
- `group_ids` extracted when present and passed to `RamanDataset`
- `tests/test_mirror_group_ids.py`: four tests against a stubbed parquet, no
  network. Without the fix, `test_group_id_is_not_treated_as_a_target` fails
  with `assert ['_group_id', 'target'] == ['target']`.

**Test run** (Windows, Python 3.13) — 46 passed, 3 failed. All three failures
are pre-existing and unrelated to this change:
- `test_data_download_integration.py` ×2: `OptionError: No such keys(s):
  'io.excel.zip.reader'`, from `kagglehub` + pandas 3.x inside `KaggleLoader`.
- `test_grouped_split.py::test_split_is_stable_across_hash_seeds`: the
  subprocess env sets `"PATH": "/usr/bin:/bin"`, which breaks the `asyncio`
  import on Windows (`WinError 10106`). Happy to open a separate issue.

Follow-up to #7. A companion PR on `raman_data` will populate `group_ids` for
the medical loaders.