### PR TITLE
Fix broken CI: skip preprocessing-restriction tests without autogluon

### DIFF
--- a/tests/test_preprocessing_restriction.py
+++ b/tests/test_preprocessing_restriction.py
@@ -8,7 +8,10 @@ enabling a step that a model's class default left off (e.g. MSC on Prep_RF, or
 SNV on a tree model) was silently a no-op.
 """
 
+import pytest
 from raman_data import TASK_TYPE
+
+pytest.importorskip("autogluon")
 
 from raman_bench.config import _ALL_PREPROCESSING_STEPS
 from raman_bench.model import AutoGluonModel


### PR DESCRIPTION
CI's "Install package (core + dev)" step (`pip install -e ".[dev]"`) never installs the `autogluon` extra, so `tests/test_preprocessing_restriction.py`'s unconditional `from raman_bench.model import AutoGluonModel` fails collection with `ModuleNotFoundError: No module named 'autogluon'`. Since `pytest` is run with `-x`, this aborts the *entire* suite on the very first collection error — no other test gets a chance to run, including new tests added by any PR (this is what happened to #8, unrelated to its own changes).

Adds the same `pytest.importorskip("autogluon")` guard every other autogluon/torch/tabpfn-dependent test file in this repo already uses (`tests/models/test_*.py`, `tests/models/test_tabular_foundation.py`).