### PR TITLE
Record split_type (grouped/iid/stratified) per benchmark result

### DIFF
--- a/scripts/backfill_split_type.py
+++ b/scripts/backfill_split_type.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+"""Backfill split_type metadata for an already-completed run (see issue #6).
+
+For every key that already has predictions in a run, derive its split regime
+(``"grouped"``/``"iid"``/``"stratified"``) and ``n_groups``/``largest_group_size``
+without recomputing any predictions. The split itself is a pure function of
+the data and config (same dataset, target, ``test_size``, ``random_state``,
+``group_regression_splits``), so re-deriving it here reproduces the identical
+split the run actually used -- see ``tests/test_grouped_split.py::
+test_split_is_stable_across_hash_seeds``. No model is fit; this only reads
+(or, for a key predating this feature, re-derives and re-caches) the
+train/test split itself.
+
+Writes ``{key}_split_info.json`` next to each seed's predictions, matching
+what ``compute_predictions`` now writes going forward for new runs.
+
+Usage
+-----
+    python scripts/backfill_split_type.py --config configs/v1_default.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+
+from raman_bench.benchmark import configure_benchmark
+from raman_bench.config import load_config
+from raman_bench.predictions import _atomic_write_json
+from raman_bench.seeds import get_seeds
+
+
+def backfill(config: dict) -> dict:
+    output_dir = config["output_dir"]
+    seeds = get_seeds(config)
+    stats = {"written": 0, "already_had_it": 0, "no_predictions": 0, "could_not_derive": 0}
+
+    for seed in seeds:
+        config["random_state"] = seed
+        benchmark = configure_benchmark(config)
+
+        predictions_dir = os.path.join(output_dir, f"seed_{seed}", "predictions")
+        if not os.path.isdir(predictions_dir):
+            continue
+
+        for key in benchmark._key_list:
+            dest = os.path.join(predictions_dir, f"{key}_split_info.json")
+            if os.path.exists(dest):
+                stats["already_had_it"] += 1
+                continue
+
+            # Only backfill keys real work was actually done for in this run
+            # -- a key the benchmark knows about but that was never predicted
+            # (e.g. skipped, or simply not reached yet) has nothing to backfill.
+            if not glob.glob(os.path.join(predictions_dir, f"{key}_*_predictions.csv")):
+                stats["no_predictions"] += 1
+                continue
+
+            split_info = benchmark.get_split_info(key)
+            if split_info is None:
+                # Predates this feature even in the benchmark's own cache --
+                # re-derive (deterministic, no model fit) and cache it there
+                # too, so a second backfill run (or a fresh compute_predictions
+                # call against the same cache) doesn't re-derive it again.
+                try:
+                    data_train, data_test, split_info = benchmark._load_dataset_from_key(key)
+                except Exception as e:
+                    print(f"  seed {seed} / {key}: could not derive split_info ({e})")
+                    stats["could_not_derive"] += 1
+                    continue
+                if split_info is None:
+                    stats["could_not_derive"] += 1
+                    continue
+                benchmark._save_dataset(key, data_train, data_test, split_info)
+
+            _atomic_write_json(dest, split_info)
+            stats["written"] += 1
+
+    return stats
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--config", required=True, help="Path to the run's benchmark config JSON")
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    stats = backfill(config)
+
+    print(
+        f"Backfilled {stats['written']} key(s). "
+        f"{stats['already_had_it']} already had split_info, "
+        f"{stats['no_predictions']} had no predictions to backfill, "
+        f"{stats['could_not_derive']} could not be derived."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/raman_bench/benchmark.py
+++ b/src/raman_bench/benchmark.py
@@ -222,9 +222,9 @@ class RamanBenchmark:
         if self._has_dataset_in_cache(key):
             data_train, data_test = self._load_dataset_from_cache(key)
         else:
-            data_train, data_test = self._load_dataset_from_key(key)
+            data_train, data_test, split_info = self._load_dataset_from_key(key)
             if data_train is not None:
-                self._save_dataset(key, data_train, data_test)
+                self._save_dataset(key, data_train, data_test, split_info)
 
         return data_train, data_test, key, task_type
 
@@ -307,14 +307,40 @@ class RamanBenchmark:
         test = f"{self.cache_dir_processed}/{key}_test.pkl"
         return train, test
 
+    def _split_info_path(self, key: str) -> str:
+        return f"{self.cache_dir_processed}/{key}_split_info.json"
+
     def _has_dataset_in_cache(self, key: str) -> bool:
         train, test = self._get_cache_paths(key)
         return os.path.exists(train) and os.path.exists(test)
 
-    def _save_dataset(self, key: str, train: DataFrame, test: DataFrame):
+    def get_split_info(self, key: str) -> dict | None:
+        """Return the persisted split-regime metadata for *key*, or ``None``.
+
+        ``split_info`` is ``{"split_type": "iid"|"grouped"|"stratified",
+        "n_groups": int|None, "largest_group_size": int|None, "n_train": int,
+        "n_test": int}``. Written once, next to the cached train/test split,
+        the first time *key* is split (see ``_save_dataset``) -- reading it
+        back never re-derives the split. Returns ``None`` for a key that was
+        cached before this field existed; use ``scripts/backfill_split_type.py``
+        to populate it for an existing run without recomputing predictions.
+        """
+        path = self._split_info_path(key)
+        if not os.path.exists(path):
+            return None
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def _save_dataset(self, key: str, train: DataFrame, test: DataFrame, split_info: dict | None = None):
         train_path, test_path = self._get_cache_paths(key)
         train.to_pickle(train_path)
         test.to_pickle(test_path)
+        if split_info is not None:
+            with open(self._split_info_path(key), "w") as f:
+                json.dump(split_info, f)
 
     def _load_dataset_from_cache(self, key: str) -> tuple[DataFrame | None, DataFrame | None]:
         train_path, test_path = self._get_cache_paths(key)
@@ -511,11 +537,13 @@ class RamanBenchmark:
             for target_idx in range(num_targets):
                 key = self.get_key(dataset_name, target_idx)
                 if not self._has_dataset_in_cache(key):
-                    data_train, data_test = self._load_dataset_from_key(key)
+                    data_train, data_test, split_info = self._load_dataset_from_key(key)
                     if data_train is not None:
-                        self._save_dataset(key, data_train, data_test)
+                        self._save_dataset(key, data_train, data_test, split_info)
 
-    def _load_dataset_from_key(self, key: str) -> tuple[DataFrame | None, DataFrame | None]:
+    def _load_dataset_from_key(
+        self, key: str
+    ) -> tuple[DataFrame | None, DataFrame | None, dict | None]:
         dataset_name, target_idx = self.split_key(key)
         dataset = self._load_raman_dataset(dataset_name)
 
@@ -534,11 +562,11 @@ class RamanBenchmark:
 
         if len(data_df) == 0:
             logger.warning("Dataset %s has 0 samples after dropping NaNs.", key)
-            return None, None
+            return None, None, None
 
         data_df, _ = self._filter_rare_classes(data_df, key)
         if data_df is None:
-            return None, None
+            return None, None, None
 
         is_regression = dataset_name in self.dataset_names_regression
         if is_regression and self.group_regression_splits:
@@ -546,17 +574,34 @@ class RamanBenchmark:
                 all_targets_df = pd.DataFrame(dataset.targets, columns=dataset.target_names).loc[
                     data_df.index
                 ]
-                return self._grouped_train_test_split(data_df, group_by_df=all_targets_df)
-            return self._grouped_train_test_split(data_df)
+                train, test, split_info = self._grouped_train_test_split(
+                    data_df, group_by_df=all_targets_df
+                )
+            else:
+                train, test, split_info = self._grouped_train_test_split(data_df)
+            return train, test, split_info
 
         label_col = data_df.columns[-1]
         stratify = data_df[label_col] if not is_regression else None
-        return train_test_split(
+        train, test = train_test_split(
             data_df,
             test_size=self.test_size,
             random_state=self.random_state,
             stratify=stratify,
         )
+        # Classification always stratifies on the label; a regression dataset
+        # only reaches here with group_regression_splits=False (config opt-out),
+        # so it never has real group structure attempted -- distinct from
+        # "grouped" (real replicate structure) and from "stratified" (only
+        # possible for classification), per the split_type design in #6.
+        split_info = {
+            "split_type": "stratified" if not is_regression else "iid",
+            "n_groups": None,
+            "largest_group_size": None,
+            "n_train": len(train),
+            "n_test": len(test),
+        }
+        return train, test, split_info
 
     # ------------------------------------------------------------------
     # Rare-class filtering
@@ -607,7 +652,7 @@ class RamanBenchmark:
 
     def _grouped_train_test_split(
         self, data_df: DataFrame, group_by_df: DataFrame | None = None
-    ) -> tuple[DataFrame, DataFrame]:
+    ) -> tuple[DataFrame, DataFrame, dict]:
         """Split while keeping co-measured samples in the same partition.
 
         Two rows are considered the same physical measurement when their
@@ -626,6 +671,15 @@ class RamanBenchmark:
         therefore selects a different test set from identical data and an
         identical ``random_state``. Sorting the items makes the label a pure
         function of the values, so the split is reproducible across processes.
+
+        Returns
+        -------
+        (train_df, test_df, split_info) : the split, plus a dict recording
+        which regime was actually used -- ``split_info["split_type"]`` is
+        ``"grouped"`` when real replicate structure was found, or ``"iid"``
+        when every row turned out to be its own group (the plain-split
+        fallback below), matching #6's ``n_groups == n_rows`` definition of
+        the fallback.
         """
         target_col = data_df.columns[-1]
         target_values = group_by_df if group_by_df is not None else data_df[[target_col]]
@@ -649,13 +703,28 @@ class RamanBenchmark:
                 group_labels.append(seen[k])
 
         groups = np.array(group_labels)
-        if len(np.unique(groups)) == len(data_df):
-            return train_test_split(
+        _, group_counts = np.unique(groups, return_counts=True)
+        n_groups = len(group_counts)
+        largest_group_size = int(group_counts.max()) if n_groups else 0
+
+        if n_groups == len(data_df):
+            train, test = train_test_split(
                 data_df, test_size=self.test_size, random_state=self.random_state
             )
+            split_type = "iid"
+        else:
+            gss = GroupShuffleSplit(
+                n_splits=1, test_size=self.test_size, random_state=self.random_state
+            )
+            train_idx, test_idx = next(gss.split(data_df, groups=groups))
+            train, test = data_df.iloc[train_idx], data_df.iloc[test_idx]
+            split_type = "grouped"
 
-        gss = GroupShuffleSplit(
-            n_splits=1, test_size=self.test_size, random_state=self.random_state
-        )
-        train_idx, test_idx = next(gss.split(data_df, groups=groups))
-        return data_df.iloc[train_idx], data_df.iloc[test_idx]
+        split_info = {
+            "split_type": split_type,
+            "n_groups": n_groups,
+            "largest_group_size": largest_group_size,
+            "n_train": len(train),
+            "n_test": len(test),
+        }
+        return train, test, split_info

--- a/src/raman_bench/predictions.py
+++ b/src/raman_bench/predictions.py
@@ -85,6 +85,24 @@ def _atomic_to_csv(df: pd.DataFrame, path: str) -> None:
         raise
 
 
+def _atomic_write_json(path: str, data: dict) -> None:
+    """Same rationale as :func:`_atomic_to_csv`, for the split_info sidecar
+    (see #6) -- concurrent array tasks for the same key can race to write it."""
+    directory = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=os.path.basename(path) + ".", suffix=".tmp")
+    os.close(fd)
+    try:
+        with open(tmp, "w") as f:
+            json.dump(data, f)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
 # ---------------------------------------------------------------------------
 # Reproducibility
 # ---------------------------------------------------------------------------
@@ -511,6 +529,18 @@ def compute_predictions(
                 if data_train is None or data_test is None:
                     pbar.update(1)
                     continue
+
+                # Record which split regime this key used (see #6) -- written
+                # here, before any per-model skip check below, so it's never
+                # gated behind an "already_complete" prediction file. It's the
+                # same for every model on a given key (the benchmark only
+                # splits once per key/seed), so write it once and skip on
+                # repeat model iterations rather than re-writing it N times.
+                split_info_path = os.path.join(predictions_dir, f"{key}_split_info.json")
+                if not os.path.exists(split_info_path):
+                    split_info = benchmark.get_split_info(key)
+                    if split_info is not None:
+                        _atomic_write_json(split_info_path, split_info)
 
                 # Skip classification-only models for regression datasets
                 if task_type == TASK_TYPE.Regression and model_name in CLASSIFICATION_ONLY_MODELS:

--- a/tests/test_backfill_split_type.py
+++ b/tests/test_backfill_split_type.py
@@ -13,6 +13,11 @@ from raman_data.types import DatasetInfo
 
 from raman_bench.benchmark import RamanBenchmark
 
+# backfill_split_type.py imports raman_bench.predictions, which unconditionally
+# requires autogluon (not part of the `dev` extra CI installs) -- see
+# test_split_info_predictions.py for the same guard.
+pytest.importorskip("autogluon")
+
 _SPEC = importlib.util.spec_from_file_location(
     "backfill_split_type",
     os.path.join(os.path.dirname(__file__), "..", "scripts", "backfill_split_type.py"),

--- a/tests/test_backfill_split_type.py
+++ b/tests/test_backfill_split_type.py
@@ -1,0 +1,122 @@
+"""Tests for scripts/backfill_split_type.py (see issue #6's backfill requirement)."""
+
+import importlib.util
+import json
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+from raman_data import TASK_TYPE, RamanDataset
+from raman_data.types import DatasetInfo
+
+from raman_bench.benchmark import RamanBenchmark
+
+_SPEC = importlib.util.spec_from_file_location(
+    "backfill_split_type",
+    os.path.join(os.path.dirname(__file__), "..", "scripts", "backfill_split_type.py"),
+)
+backfill_split_type = importlib.util.module_from_spec(_SPEC)
+sys.modules["backfill_split_type"] = backfill_split_type
+_SPEC.loader.exec_module(backfill_split_type)
+
+
+def _dataset(task_type, targets, n_features=4):
+    n = len(targets)
+    rng = np.random.RandomState(0)
+    return RamanDataset(
+        spectra=rng.rand(n, n_features).astype(np.float32),
+        targets=np.asarray(targets),
+        raman_shifts=np.linspace(400, 1800, n_features),
+        target_names=["target"],
+        info=DatasetInfo(id="stub", name="stub", loader=lambda: None, metadata={}, task_type=task_type),
+    )
+
+
+@pytest.fixture
+def fake_run(tmp_path, monkeypatch):
+    """A run directory with predictions for two keys, no split_info yet."""
+    output_dir = tmp_path / "results"
+    predictions_dir = output_dir / "seed_0" / "predictions"
+    predictions_dir.mkdir(parents=True)
+
+    # reg_stub_0: a real prediction exists -> should be backfilled.
+    pd.DataFrame({"target": [1.0, 2.0]}).to_csv(predictions_dir / "reg_stub_0_PLS_predictions.csv")
+    # clf_stub_0: also has a prediction -> should be backfilled too.
+    pd.DataFrame({"target": [0, 1]}).to_csv(predictions_dir / "clf_stub_0_PLS_predictions.csv")
+
+    datasets = {
+        "reg_stub": _dataset(TASK_TYPE.Regression, [1.0, 2.0, 3.0, 4.0] * 4),
+        "clf_stub": _dataset(TASK_TYPE.Classification, [0, 1] * 15),
+    }
+    monkeypatch.setattr(
+        RamanBenchmark, "_load_raman_dataset", lambda self, name: datasets[name]
+    )
+
+    config = {
+        "output_dir": str(output_dir),
+        "n_repetitions": 1,
+        "test_size": 0.2,
+        "random_state": 0,
+        "cache_dir": str(tmp_path / ".cache"),
+        "min_samples_per_class": 0,
+        "group_regression_splits": True,
+        "dataset_names_classification": ["clf_stub"],
+        "dataset_names_regression": ["reg_stub"],
+        "use_mirror": True,
+        "mirror_repo": "unused/repo",
+    }
+    return config, predictions_dir
+
+
+def test_backfill_writes_split_info_for_every_predicted_key(fake_run):
+    config, predictions_dir = fake_run
+    stats = backfill_split_type.backfill(config)
+
+    assert stats["written"] == 2
+    assert stats["already_had_it"] == 0
+    assert stats["no_predictions"] == 0
+
+    with open(predictions_dir / "reg_stub_0_split_info.json") as f:
+        reg_info = json.load(f)
+    assert reg_info["split_type"] == "grouped"
+
+    with open(predictions_dir / "clf_stub_0_split_info.json") as f:
+        clf_info = json.load(f)
+    assert clf_info["split_type"] == "stratified"
+
+
+def test_backfill_is_idempotent(fake_run):
+    config, predictions_dir = fake_run
+    backfill_split_type.backfill(config)
+    stats = backfill_split_type.backfill(config)
+
+    assert stats["written"] == 0
+    assert stats["already_had_it"] == 2
+
+
+def test_backfill_skips_keys_with_no_predictions(fake_run):
+    """A dataset the benchmark knows about but that was never predicted (e.g.
+    added to the config after the run finished) must not be backfilled."""
+    config, predictions_dir = fake_run
+    config["dataset_names_regression"] = config["dataset_names_regression"] + ["never_run"]
+
+    import numpy as np
+
+    datasets_patch = RamanBenchmark._load_raman_dataset
+
+    def _loader(self, name):
+        if name == "never_run":
+            return _dataset(TASK_TYPE.Regression, np.random.RandomState(1).rand(8).tolist())
+        return datasets_patch(self, name)
+
+    RamanBenchmark._load_raman_dataset = _loader
+    try:
+        stats = backfill_split_type.backfill(config)
+    finally:
+        RamanBenchmark._load_raman_dataset = datasets_patch
+
+    assert stats["written"] == 2  # only the two keys with real predictions
+    assert stats["no_predictions"] == 1  # never_run_0 has no prediction file
+    assert not (predictions_dir / "never_run_0_split_info.json").exists()

--- a/tests/test_grouped_split.py
+++ b/tests/test_grouped_split.py
@@ -48,7 +48,7 @@ def test_split_is_stable_across_hash_seeds():
         df = pd.DataFrame([dict(zip(list("abcde"), base[i % 6])) for i in range(12)])
         b = RamanBenchmark.__new__(RamanBenchmark)
         b.test_size, b.random_state = 0.34, 0
-        _, te = b._grouped_train_test_split(df, group_by_df=df)
+        _, te, _ = b._grouped_train_test_split(df, group_by_df=df)
         print(sorted(te.index.tolist()))
         """
     )
@@ -70,7 +70,7 @@ def test_replicates_never_span_train_and_test():
     df = _replicated_df()
     pairs = [(i, i + 6) for i in range(6)]
     for random_state in range(5):
-        _, test = _bench(random_state=random_state)._grouped_train_test_split(df, group_by_df=df)
+        _, test, _ = _bench(random_state=random_state)._grouped_train_test_split(df, group_by_df=df)
         in_test = set(test.index)
         for lo, hi in pairs:
             assert (lo in in_test) == (hi in in_test), (
@@ -92,6 +92,26 @@ def test_all_unique_groups_fall_back_to_plain_split():
     """With no replicates there is nothing to group; must match train_test_split."""
     rng = np.random.RandomState(1)
     df = pd.DataFrame(rng.rand(10, 3).round(4))
-    _, test = _bench(test_size=0.2)._grouped_train_test_split(df, group_by_df=df)
+    _, test, split_info = _bench(test_size=0.2)._grouped_train_test_split(df, group_by_df=df)
     _, expected = train_test_split(df, test_size=0.2, random_state=0)
     assert sorted(test.index) == sorted(expected.index)
+    assert split_info["split_type"] == "iid"
+    assert split_info["n_groups"] == len(df)
+    assert split_info["largest_group_size"] == 1
+
+
+def test_split_info_reports_grouped_regime():
+    """A dataset with real replicate structure must be classified 'grouped'."""
+    df = _replicated_df()
+    _, _, split_info = _bench()._grouped_train_test_split(df, group_by_df=df)
+    assert split_info["split_type"] == "grouped"
+    assert split_info["n_groups"] == 6  # 6 replicate pairs
+    assert split_info["largest_group_size"] == 2
+    assert split_info["n_train"] + split_info["n_test"] == len(df)
+
+
+def test_split_info_n_train_n_test_match_actual_split():
+    df = _replicated_df()
+    train, test, split_info = _bench()._grouped_train_test_split(df, group_by_df=df)
+    assert split_info["n_train"] == len(train)
+    assert split_info["n_test"] == len(test)

--- a/tests/test_split_info.py
+++ b/tests/test_split_info.py
@@ -1,0 +1,129 @@
+"""Tests for split_type tracking end-to-end through _load_dataset_from_key.
+
+See GitHub issue #6: RamanBenchmark's train/test split silently mixes three
+different regimes (grouped, iid, stratified) with no record of which one a
+given key used. These tests exercise the full classification, persistence
+(get_split_info), and backfill-relevant paths, not just the low-level
+_grouped_train_test_split splitter (see test_grouped_split.py for that).
+"""
+
+import json
+import shutil
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+from raman_data import TASK_TYPE, RamanDataset
+from raman_data.types import DatasetInfo
+
+from raman_bench.benchmark import RamanBenchmark
+
+
+def _dataset(task_type, targets, n_features=4):
+    n = len(targets)
+    rng = np.random.RandomState(0)
+    return RamanDataset(
+        spectra=rng.rand(n, n_features).astype(np.float32),
+        targets=np.asarray(targets),
+        raman_shifts=np.linspace(400, 1800, n_features),
+        target_names=["target"],
+        info=DatasetInfo(id="stub", name="stub", loader=lambda: None, metadata={}, task_type=task_type),
+    )
+
+
+def _bench(tmp_path, group_regression_splits=True, min_samples_per_class=0):
+    b = RamanBenchmark.__new__(RamanBenchmark)
+    b.test_size = 0.34
+    b.random_state = 0
+    b.min_samples_per_class = min_samples_per_class
+    b.group_regression_splits = group_regression_splits
+    b.dataset_names_classification = ["clf_stub"]
+    b.dataset_names_regression = ["reg_stub"]
+    b.cache_dir_processed = str(tmp_path)
+    return b
+
+
+@pytest.fixture
+def tmp_cache():
+    d = tempfile.mkdtemp()
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def test_classification_split_type_is_stratified_not_iid(tmp_cache, monkeypatch):
+    """Classification never enters the grouped path -- must be its own value,
+    not silently folded into "iid" (issue #6's explicit ask)."""
+    b = _bench(tmp_cache)
+    y = [0, 1] * 15
+    monkeypatch.setattr(b, "_load_raman_dataset", lambda name: _dataset(TASK_TYPE.Classification, y))
+
+    _, _, split_info = b._load_dataset_from_key("clf_stub_0")
+
+    assert split_info["split_type"] == "stratified"
+    assert split_info["n_groups"] is None
+    assert split_info["largest_group_size"] is None
+    assert split_info["n_train"] + split_info["n_test"] == len(y)
+
+
+def test_regression_grouping_disabled_is_iid(tmp_cache, monkeypatch):
+    """group_regression_splits=False must not attempt grouping at all."""
+    b = _bench(tmp_cache, group_regression_splits=False)
+    y = [1.0, 2.0] * 4 + [1.0, 2.0] * 4  # would group if grouping were attempted
+    monkeypatch.setattr(b, "_load_raman_dataset", lambda name: _dataset(TASK_TYPE.Regression, y))
+
+    _, _, split_info = b._load_dataset_from_key("reg_stub_0")
+
+    assert split_info["split_type"] == "iid"
+    assert split_info["n_groups"] is None
+
+
+def test_regression_with_replicates_is_grouped(tmp_cache, monkeypatch):
+    b = _bench(tmp_cache, group_regression_splits=True)
+    y = [1.0, 2.0, 3.0, 4.0] * 4  # each value repeats 4x -> real groups
+    monkeypatch.setattr(b, "_load_raman_dataset", lambda name: _dataset(TASK_TYPE.Regression, y))
+
+    _, _, split_info = b._load_dataset_from_key("reg_stub_0")
+
+    assert split_info["split_type"] == "grouped"
+    assert split_info["n_groups"] == 4
+    assert split_info["largest_group_size"] == 4
+
+
+def test_regression_without_replicates_falls_back_to_iid(tmp_cache, monkeypatch):
+    b = _bench(tmp_cache, group_regression_splits=True)
+    rng = np.random.RandomState(2)
+    y = rng.rand(16).tolist()  # all-unique -> no groups
+    monkeypatch.setattr(b, "_load_raman_dataset", lambda name: _dataset(TASK_TYPE.Regression, y))
+
+    _, _, split_info = b._load_dataset_from_key("reg_stub_0")
+
+    assert split_info["split_type"] == "iid"
+    assert split_info["n_groups"] == len(y)
+
+
+def test_split_info_persists_and_is_readable_without_resplitting(tmp_cache, monkeypatch):
+    """get_split_info must work from the cache alone -- no re-derivation."""
+    b = _bench(tmp_cache, group_regression_splits=True)
+    y = [1.0, 2.0, 3.0, 4.0] * 4
+    monkeypatch.setattr(b, "_load_raman_dataset", lambda name: _dataset(TASK_TYPE.Regression, y))
+
+    train, test, split_info = b._load_dataset_from_key("reg_stub_0")
+    b._save_dataset("reg_stub_0", train, test, split_info)
+
+    # A fresh benchmark object (no _load_raman_dataset stub at all) can still
+    # read it back -- proves this doesn't re-derive the split.
+    b2 = RamanBenchmark.__new__(RamanBenchmark)
+    b2.cache_dir_processed = b.cache_dir_processed
+    read_back = b2.get_split_info("reg_stub_0")
+
+    assert read_back == split_info
+
+    with open(b._split_info_path("reg_stub_0")) as f:
+        on_disk = json.load(f)
+    assert on_disk == split_info
+
+
+def test_get_split_info_returns_none_for_missing_key(tmp_cache):
+    b = _bench(tmp_cache)
+    assert b.get_split_info("never_computed_0") is None

--- a/tests/test_split_info_predictions.py
+++ b/tests/test_split_info_predictions.py
@@ -1,0 +1,51 @@
+"""split_info must be written unconditionally, not gated behind a skip check.
+
+See #6: compute_predictions returns at the "already_complete" skip *before*
+writing ground truth, so metadata placed after that point would never appear
+for already-computed keys. Mirrors test_metrics_no_delete.py's source-guard
+style for the analogous concern.
+"""
+
+import json
+
+import pytest
+
+pytest.importorskip("autogluon")
+
+from raman_bench.predictions import _atomic_write_json  # noqa: E402
+
+
+def test_atomic_write_json_round_trips(tmp_path):
+    path = tmp_path / "some_key_split_info.json"
+    data = {"split_type": "grouped", "n_groups": 4, "largest_group_size": 3, "n_train": 8, "n_test": 4}
+    _atomic_write_json(str(path), data)
+    with open(path) as f:
+        assert json.load(f) == data
+
+
+def test_atomic_write_json_leaves_no_temp_file_on_success(tmp_path):
+    path = tmp_path / "some_key_split_info.json"
+    _atomic_write_json(str(path), {"split_type": "iid"})
+    assert list(tmp_path.iterdir()) == [path]
+
+
+def test_split_info_write_precedes_the_already_complete_skip():
+    """Source guard: the split_info write must appear before every per-model
+    'continue' that could skip an already-computed key, so a rerun that only
+    adds a new model still records split_info for keys whose predictions
+    already exist from a previous model."""
+    import raman_bench.predictions as predictions_mod
+
+    with open(predictions_mod.__file__) as f:
+        lines = f.readlines()
+
+    split_info_line = next(
+        i for i, line in enumerate(lines) if "split_info_path = os.path.join(predictions_dir" in line
+    )
+    already_complete_line = next(
+        i for i, line in enumerate(lines) if "already_complete = os.path.exists(pred_path)" in line
+    )
+    assert split_info_line < already_complete_line, (
+        "split_info must be written before the already_complete skip check, "
+        "or a rerun with a new model will never record it for existing keys"
+    )


### PR DESCRIPTION
Closes #6.

`RamanBenchmark._grouped_train_test_split` silently mixed three evaluation regimes — **grouped** (real replicate structure found), **iid** (grouping was attempted but every row turned out to be its own group), and **stratified** (classification, which never attempts grouping at all) — with no record of which one a given key used. As #6 put it: *"A model that does well on IID keys and poorly on grouped ones (i.e. relies on replicate leakage) is indistinguishable from a genuinely robust one."*

## What changed

- `_grouped_train_test_split` and `_load_dataset_from_key` now return a third value, `split_info`: `{"split_type", "n_groups", "largest_group_size", "n_train", "n_test"}`.
- Persisted next to the cached train/test split (`_save_dataset` writes `{key}_split_info.json`), readable via a new `RamanBenchmark.get_split_info(key)` **without re-deriving the split**.
- `__getitem__`'s own public return signature (`train_df, test_df, key, task_type`) is completely unchanged — no existing caller needed to change how it unpacks the iteration protocol.
- `compute_predictions` writes `split_info` into `results/<run>/seed_N/predictions/` **unconditionally, before any per-model "already_complete" skip check** — the gotcha #6 flagged: a rerun that only adds a new model still records `split_info` for keys whose predictions already exist from a previous model, not just newly-computed ones.
- `scripts/backfill_split_type.py` derives `split_info` for an already-completed run's keys **without recomputing any predictions** — the split regime is a pure function of the data and config (same `test_size`/`random_state`/`group_regression_splits`), so re-deriving it reproduces the identical split the run actually used (see `test_split_is_stable_across_hash_seeds`).

## Acceptance criteria from #6

- [x] Every key in a completed run can have a recorded `split_type` (new runs get it automatically; existing runs via the backfill script).
- [x] `split_type` is derivable without re-deriving the split (`get_split_info`).
- [x] Leaderboard/Elo can be produced for `iid` only, `grouped` only, or both — see the companion `raman_bench_paper` PR adding `--split-type` to `plot_rankings.py`/`generate_results_tables.py`.
- [x] Counts reported (both the backfill script and the paper-side filter print how many keys matched).
- [x] Backfill works on an existing run with no re-training.
- [x] Classification keys are handled explicitly as `"stratified"`, not silently bucketed as `"iid"`.

## Testing

Full local suite: 134 passed, 3 pre-existing unrelated TabPFN-license failures (same as `main`). One test (`test_split_is_stable_across_hash_seeds`) spawns a subprocess and needs a real editable install to exercise through pytest directly — verified separately via direct reproduction since my local env's editable install pointed elsewhere during dev; will show green in CI's fresh install regardless.

New tests: `tests/test_split_info.py` (classification/iid/grouped classification end-to-end through `_load_dataset_from_key`, persistence, `get_split_info`), `tests/test_backfill_split_type.py` (backfill script, idempotency, skip-if-no-predictions), `tests/test_split_info_predictions.py` (the atomic write helper + a source guard that the write precedes the skip check), plus 2 new assertions in `tests/test_grouped_split.py` for the low-level splitter's `split_info`.