### PR TITLE
Load credentials from .env automatically via python-dotenv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "tqdm>=4.64,<5.0",
     "raman-data>=1.2.6",
     "torch>=2.0,<3.0",
+    "python-dotenv>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/raman_bench/__init__.py
+++ b/src/raman_bench/__init__.py
@@ -35,6 +35,18 @@ Quick Start
 """
 
 import importlib
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Load credentials (TABPFN_TOKEN, HUGGING_FACE_HUB_TOKEN, etc.) from a .env file.
+# Two locations, in priority order: this repo's own root (works for editable
+# installs regardless of the caller's working directory), then whatever .env
+# python-dotenv finds searching upward from the current working directory (e.g.
+# a caller project's own .env). Neither overrides a variable already set in the
+# real environment (load_dotenv's default override=False).
+load_dotenv(Path(__file__).resolve().parents[2] / ".env")
+load_dotenv()
 
 __version__ = "0.1.0"
 __author__ = "Mario Koddenbrock (HTW Berlin), Christoph Lange (TU Berlin)"


### PR DESCRIPTION
## Summary
- \`.env\` at the repo root holds \`TABPFN_TOKEN\`, \`HUGGING_FACE_HUB_TOKEN\`, and other project credentials, but nothing loaded it — it only worked if manually sourced into the shell first, which silently broke TabPFN/RamanPFN tests and any run needing those tokens.
- Adds \`python-dotenv\` as a core dependency and loads \`.env\` from this repo's own root (via \`__file__\`, so it works regardless of the caller's working directory — e.g. importing \`raman_bench\` from another project), falling back to python-dotenv's normal upward search. Never overrides a variable already set in the real environment.

## Test plan
- [x] Verified in a completely clean environment (\`env -i\`, no manually-exported vars): \`import raman_bench\` now sets \`TABPFN_TOKEN\` correctly
- [x] Full test suite: 392 passed, 0 failed (previously 6 failed with \`TabPFNLicenseError\` before this fix)