### PR TITLE
Fix CI: guard autogluon/tabarena-dependent tests, apply black/isort

### DIFF
--- a/src/raman_bench/evaluation.py
+++ b/src/raman_bench/evaluation.py
@@ -296,8 +296,11 @@ def compute_metrics_from_predictions(config):
                                     "%s / %s (seed %s): proba columns %s do not match "
                                     "the fold's classes %s -- skipping roc_auc/log_loss "
                                     "for this row instead of risking a misaligned score.",
-                                    key, model_name, seed,
-                                    sorted(proba_df.columns), class_order,
+                                    key,
+                                    model_name,
+                                    seed,
+                                    sorted(proba_df.columns),
+                                    class_order,
                                 )
 
                 row.update(

--- a/src/raman_bench/metrics/classification.py
+++ b/src/raman_bench/metrics/classification.py
@@ -124,9 +124,7 @@ class ClassificationMetrics:
                 UserWarning,
                 stacklevel=2,
             )
-        y_proba = np.divide(
-            y_proba, row_sums, out=np.zeros_like(y_proba), where=row_sums != 0
-        )
+        y_proba = np.divide(y_proba, row_sums, out=np.zeros_like(y_proba), where=row_sums != 0)
         with warnings.catch_warnings():
             # Belt-and-suspenders: rows now sum to 1 to machine precision, but suppress
             # sklearn's sum-to-one warning so a future dtype change can't reintroduce it.

--- a/src/raman_bench/models/custom/pls/model.py
+++ b/src/raman_bench/models/custom/pls/model.py
@@ -44,13 +44,17 @@ class PLSModel(BaseEstimator):
             for i, val in enumerate(y_arr):
                 y_encoded[i, self._class_to_idx[val]] = 1.0
             self.model_ = PLSRegression(
-                n_components=n_components, max_iter=self.max_iter, scale=self.scale,
+                n_components=n_components,
+                max_iter=self.max_iter,
+                scale=self.scale,
                 tol=self.tol,
             )
             self.model_.fit(X_np, y_encoded)
         else:
             self.model_ = PLSRegression(
-                n_components=n_components, max_iter=self.max_iter, scale=self.scale,
+                n_components=n_components,
+                max_iter=self.max_iter,
+                scale=self.scale,
                 tol=self.tol,
             ).fit(X_np, y_arr)
 

--- a/src/raman_bench/predictions.py
+++ b/src/raman_bench/predictions.py
@@ -74,9 +74,7 @@ def _atomic_to_csv(df: pd.DataFrame, path: str) -> None:
     wins is the correct resolution.
     """
     directory = os.path.dirname(path) or "."
-    fd, tmp = tempfile.mkstemp(
-        dir=directory, prefix=os.path.basename(path) + ".", suffix=".tmp"
-    )
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=os.path.basename(path) + ".", suffix=".tmp")
     os.close(fd)
     try:
         df.to_csv(tmp, index=True)

--- a/src/raman_bench/preprocessing/mixin.py
+++ b/src/raman_bench/preprocessing/mixin.py
@@ -80,10 +80,12 @@ except ImportError as _ag_err:
     ) from _ag_err
 
 from raman_bench.preprocessing.raman_preprocessing import (
+    baseline_correction_asls,  # also covers fluorescence removal at high lam / low p
+)
+from raman_bench.preprocessing.raman_preprocessing import (
     augment_spectra,
     baseline_correction_airpls,
     baseline_correction_arpls,
-    baseline_correction_asls,  # also covers fluorescence removal at high lam / low p
     cosmic_ray_removal,
     crop_spectra,
     denoise_savgol,
@@ -622,12 +624,8 @@ class RamanPreprocessingMixin:
         if lvse_enabled:
             n_regions = params.get("prep_lvse_n_regions", 16)
             k_per_region = params.get("prep_lvse_k_per_region", 4)
-            logger.debug(
-                "Fit — LVSE: n_regions=%s, k_per_region=%s", n_regions, k_per_region
-            )
-            lvse_state, lvse_out = lvse_fit(
-                X, n_regions=n_regions, k_per_region=k_per_region
-            )
+            logger.debug("Fit — LVSE: n_regions=%s, k_per_region=%s", n_regions, k_per_region)
+            lvse_state, lvse_out = lvse_fit(X, n_regions=n_regions, k_per_region=k_per_region)
             self._lvse_region_bounds = lvse_state["region_indices"]
             self._lvse_means = lvse_state["means"]
             self._lvse_stds = lvse_state["stds"]

--- a/src/raman_bench/preprocessing/raman_preprocessing.py
+++ b/src/raman_bench/preprocessing/raman_preprocessing.py
@@ -561,9 +561,7 @@ def wavelet_denoise(X, wavelet="sym7", level=4):
         sigma = np.median(np.abs(finest_detail)) / 0.6745
         uthresh = sigma * np.sqrt(2.0 * np.log(n_features))
 
-        coeffs = [coeffs[0]] + [
-            pywt.threshold(c, uthresh, mode="soft") for c in coeffs[1:]
-        ]
+        coeffs = [coeffs[0]] + [pywt.threshold(c, uthresh, mode="soft") for c in coeffs[1:]]
         rec = pywt.waverec(coeffs, wavelet)
         X_denoised[i] = rec[:n_features]
 

--- a/src/raman_bench/preprocessing/wrapped_models.py
+++ b/src/raman_bench/preprocessing/wrapped_models.py
@@ -372,10 +372,14 @@ Prep_TABICL = _make_optional_prep_class(
     "Prep_TABICL", TabICLModel, _default_auxiliary_params_extra=_NO_FOUNDATION_MODEL_FEATURE_CAP
 )
 Prep_REALTABPFN_V2 = _make_optional_prep_class(
-    "Prep_REALTABPFN_V2", RealTabPFNv2Model, _default_auxiliary_params_extra=_NO_FOUNDATION_MODEL_FEATURE_CAP
+    "Prep_REALTABPFN_V2",
+    RealTabPFNv2Model,
+    _default_auxiliary_params_extra=_NO_FOUNDATION_MODEL_FEATURE_CAP,
 )
 Prep_REALTABPFN_V25 = _make_optional_prep_class(
-    "Prep_REALTABPFN_V25", RealTabPFNv25Model, _default_auxiliary_params_extra=_NO_FOUNDATION_MODEL_FEATURE_CAP
+    "Prep_REALTABPFN_V25",
+    RealTabPFNv25Model,
+    _default_auxiliary_params_extra=_NO_FOUNDATION_MODEL_FEATURE_CAP,
 )
 Prep_REALTABPFN_V26 = _make_optional_prep_class("Prep_REALTABPFN_V26", RealTabPFNv26Model)
 # Wraps tabarena.models.tabpfn_3.model.TabPFN3Model (TabArena's own, actively-maintained
@@ -558,6 +562,7 @@ else:
             default_auxiliary_params = super()._get_default_auxiliary_params()
             default_auxiliary_params.update(_NO_FOUNDATION_MODEL_FEATURE_CAP)
             return default_auxiliary_params
+
 
 # TabSTAR builds a per-column LM text embedding (see tabstar/arch/arch.py's
 # get_textual_embedding): memory scales with FEATURE count, not row count --

--- a/src/raman_bench/splitting.py
+++ b/src/raman_bench/splitting.py
@@ -223,7 +223,9 @@ def _repeated_kfold_splits_labeled(
         splits = []
         for repeat_idx in range(n_repeats):
             if problem_type == "classification":
-                splitter = StratifiedGroupKFold(n_splits=n_splits, shuffle=True, random_state=repeat_idx)
+                splitter = StratifiedGroupKFold(
+                    n_splits=n_splits, shuffle=True, random_state=repeat_idx
+                )
                 repeat_splits = splitter.split(df, df[label_col], groups=groups)
             else:
                 splitter = GroupKFold(n_splits=n_splits, shuffle=True, random_state=repeat_idx)
@@ -267,8 +269,12 @@ def _repeated_kfold_splits(
     labeled_mask = df[label_col].notna().to_numpy()
     if labeled_mask.all():
         return _repeated_kfold_splits_labeled(
-            df, label_col=label_col, problem_type=problem_type,
-            n_repeats=n_repeats, n_splits=n_splits, group_col=group_col,
+            df,
+            label_col=label_col,
+            problem_type=problem_type,
+            n_repeats=n_repeats,
+            n_splits=n_splits,
+            group_col=group_col,
         )
 
     labeled_positions = np.flatnonzero(labeled_mask)
@@ -276,14 +282,21 @@ def _repeated_kfold_splits(
     df_labeled = df.iloc[labeled_positions].reset_index(drop=True)
 
     labeled_splits = _repeated_kfold_splits_labeled(
-        df_labeled, label_col=label_col, problem_type=problem_type,
-        n_repeats=n_repeats, n_splits=n_splits, group_col=group_col,
+        df_labeled,
+        label_col=label_col,
+        problem_type=problem_type,
+        n_repeats=n_repeats,
+        n_splits=n_splits,
+        group_col=group_col,
     )
 
     has_groups = group_col is not None and group_col in df.columns and df[group_col].notna().any()
     if not has_groups:
         return [
-            (np.concatenate([labeled_positions[train_idx], unlabeled_positions]), labeled_positions[test_idx])
+            (
+                np.concatenate([labeled_positions[train_idx], unlabeled_positions]),
+                labeled_positions[test_idx],
+            )
             for train_idx, test_idx in labeled_splits
         ]
 

--- a/tests/models/test_coatnet.py
+++ b/tests/models/test_coatnet.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 torch = pytest.importorskip("torch")
+pytest.importorskip("autogluon")
 
 from raman_bench.models.custom.coatnet.model import (  # noqa: E402
     CoAtNetModel,

--- a/tests/models/test_deep_cnn.py
+++ b/tests/models/test_deep_cnn.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 torch = pytest.importorskip("torch")
+pytest.importorskip("autogluon")
 
 from raman_bench.models.custom.deepcnn.model import (  # noqa: E402
     DeepCNNModel,

--- a/tests/models/test_fcresnext.py
+++ b/tests/models/test_fcresnext.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 torch = pytest.importorskip("torch")
+pytest.importorskip("autogluon")
 
 from raman_bench.models.custom.fcresnext.model import (  # noqa: E402
     FCResNeXtModel,

--- a/tests/models/test_pls.py
+++ b/tests/models/test_pls.py
@@ -3,7 +3,9 @@
 import numpy as np
 import pytest
 
-from raman_bench.models.custom.pls.model import PLSModel
+pytest.importorskip("autogluon")
+
+from raman_bench.models.custom.pls.model import PLSModel  # noqa: E402
 
 
 def _clf(n=60, f=30, n_classes=3, seed=0):

--- a/tests/models/test_raman_net.py
+++ b/tests/models/test_raman_net.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 torch = pytest.importorskip("torch")
+pytest.importorskip("autogluon")
 
 from raman_bench.models.custom.ramannet.model import (  # noqa: E402
     RamanNetModel,

--- a/tests/models/test_ramanformer.py
+++ b/tests/models/test_ramanformer.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 torch = pytest.importorskip("torch")
+pytest.importorskip("autogluon")
 
 from raman_bench.models.custom.ramanformer.model import (  # noqa: E402
     RamanFormerModel,

--- a/tests/models/test_ramanpfn.py
+++ b/tests/models/test_ramanpfn.py
@@ -1,8 +1,11 @@
 """Tests for RamanPFNModel."""
 
 import numpy as np
+import pytest
 
-from raman_bench.models.custom.ramanpfn.model import RamanPFNModel
+pytest.importorskip("autogluon")
+
+from raman_bench.models.custom.ramanpfn.model import RamanPFNModel  # noqa: E402
 
 
 def _clf(n=60, f=120, n_classes=3, seed=0):

--- a/tests/models/test_ramantransformer.py
+++ b/tests/models/test_ramantransformer.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 torch = pytest.importorskip("torch")
+pytest.importorskip("autogluon")
 
 from raman_bench.models.custom.ramantransformer.model import (  # noqa: E402
     RamanTransformerModel,

--- a/tests/models/test_rezeronet.py
+++ b/tests/models/test_rezeronet.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 torch = pytest.importorskip("torch")
+pytest.importorskip("autogluon")
 
 from raman_bench.models.custom.rezeronet.model import (  # noqa: E402
     ReZeroNetModel,

--- a/tests/models/test_ridge.py
+++ b/tests/models/test_ridge.py
@@ -1,8 +1,11 @@
 """Tests for RidgeModel."""
 
 import numpy as np
+import pytest
 
-from raman_bench.models.custom.ridge.model import RidgeModel
+pytest.importorskip("autogluon")
+
+from raman_bench.models.custom.ridge.model import RidgeModel  # noqa: E402
 
 
 def _clf(n=60, f=30, n_classes=3, seed=0):

--- a/tests/models/test_sanet.py
+++ b/tests/models/test_sanet.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 torch = pytest.importorskip("torch")
+pytest.importorskip("autogluon")
 
 from raman_bench.models.custom.sanet.model import (  # noqa: E402
     SANetModel,

--- a/tests/models/test_sktime_models.py
+++ b/tests/models/test_sktime_models.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 pytest.importorskip("sktime")
+pytest.importorskip("autogluon")
 
 from raman_bench.models.custom.arsenal.model import ArsenalModel  # noqa: E402
 from raman_bench.models.custom.rocket.model import RocketModel  # noqa: E402

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -23,7 +23,9 @@ import pytest
 
 SRC = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-    "src", "raman_bench", "predictions.py",
+    "src",
+    "raman_bench",
+    "predictions.py",
 )
 
 BIG, SMALL = 120_000, 90_000
@@ -36,10 +38,7 @@ def _load_atomic_to_csv():
     only, so parse the one function out and exec it. It is the real source, not a copy.
     """
     tree = ast.parse(open(SRC).read())
-    fn = next(
-        n for n in tree.body
-        if isinstance(n, ast.FunctionDef) and n.name == "_atomic_to_csv"
-    )
+    fn = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "_atomic_to_csv")
     ns = {"os": os, "tempfile": tempfile, "pd": pd}
     exec(compile(ast.Module([fn], []), SRC, "exec"), ns)
     return ns["_atomic_to_csv"]
@@ -122,9 +121,7 @@ def test_plain_to_csv_is_what_tore(tmp_path):
         return  # torn badly enough that the parser rejects it: bug reproduced
 
     corrupt = (
-        len(df) not in (BIG, SMALL)
-        or df.index.nunique() != len(df)
-        or bool(df.isna().any().any())
+        len(df) not in (BIG, SMALL) or df.index.nunique() != len(df) or bool(df.isna().any().any())
     )
     if not corrupt:
         pytest.skip("the writers did not overlap this run; the race is timing-dependent")

--- a/tests/test_capacity_pending_gate.py
+++ b/tests/test_capacity_pending_gate.py
@@ -42,7 +42,8 @@ def _load_opportunistic_scheduler():
     if str(CLUSTER_DIR) not in sys.path:
         sys.path.insert(0, str(CLUSTER_DIR))
     spec = importlib.util.spec_from_file_location(
-        "_opportunistic_scheduler_under_test_capacity_pending", CLUSTER_DIR / "opportunistic_scheduler.py"
+        "_opportunistic_scheduler_under_test_capacity_pending",
+        CLUSTER_DIR / "opportunistic_scheduler.py",
     )
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -70,7 +71,9 @@ def _fake_run(sinfo_line: str, squeue_states: list[str]):
     return fake_run
 
 
-def _fake_run_distinguishing_r(sinfo_line: str, expanded_states: list[str], collapsed_states: list[str]):
+def _fake_run_distinguishing_r(
+    sinfo_line: str, expanded_states: list[str], collapsed_states: list[str]
+):
     """Like ``_fake_run``, but returns DIFFERENT squeue output depending on
     whether ``-r`` is in the command -- models the real behavior squeue
     itself has (an array with a large still-pending remainder collapses to
@@ -186,8 +189,10 @@ def test_max_pending_does_not_misfire_on_normal_throttled_backlog(scheduler):
     collapsed view it was designed around."""
     fake_run = _fake_run_distinguishing_r(
         "128/128/0/256",
-        expanded_states=["RUNNING"] * 8 + ["PENDING"] * 32,  # -r: true count, 40 total (under courtesy_ceiling)
-        collapsed_states=["RUNNING"] * 8 + ["PENDING"] * 1,  # no -r: 1 collapsed line for the pending remainder
+        expanded_states=["RUNNING"] * 8
+        + ["PENDING"] * 32,  # -r: true count, 40 total (under courtesy_ceiling)
+        collapsed_states=["RUNNING"] * 8
+        + ["PENDING"] * 1,  # no -r: 1 collapsed line for the pending remainder
     )
     with patch("subprocess.run", side_effect=fake_run):
         has_room, reason = scheduler.check_capacity(
@@ -229,8 +234,11 @@ def test_max_concurrent_arrays_blocks_a_second_array(scheduler):
     )
     with patch("subprocess.run", side_effect=fake_run):
         has_room, reason = scheduler.check_capacity(
-            {"partition": "Debug_node"}, min_idle_cpus=32, courtesy_ceiling=200,
-            max_pending=50, max_concurrent_arrays=1,
+            {"partition": "Debug_node"},
+            min_idle_cpus=32,
+            courtesy_ceiling=200,
+            max_pending=50,
+            max_concurrent_arrays=1,
         )
     assert has_room is False
     assert "max_concurrent_arrays" in reason
@@ -240,8 +248,11 @@ def test_max_concurrent_arrays_allows_room_when_none_resident(scheduler):
     fake_run = _fake_run_with_job_names("128/128/0/256", [])
     with patch("subprocess.run", side_effect=fake_run):
         has_room, reason = scheduler.check_capacity(
-            {"partition": "Debug_node"}, min_idle_cpus=32, courtesy_ceiling=200,
-            max_pending=50, max_concurrent_arrays=1,
+            {"partition": "Debug_node"},
+            min_idle_cpus=32,
+            courtesy_ceiling=200,
+            max_pending=50,
+            max_concurrent_arrays=1,
         )
     assert has_room is True
 
@@ -256,10 +267,15 @@ def test_max_concurrent_arrays_counts_distinct_names_not_tasks(scheduler):
     )
     with patch("subprocess.run", side_effect=fake_run):
         has_room, reason = scheduler.check_capacity(
-            {"partition": "Debug_node"}, min_idle_cpus=32, courtesy_ceiling=500,
-            max_pending=250, max_concurrent_arrays=1,
+            {"partition": "Debug_node"},
+            min_idle_cpus=32,
+            courtesy_ceiling=500,
+            max_pending=250,
+            max_concurrent_arrays=1,
         )
-    assert has_room is False  # courtesy_ceiling(500) not hit at 200, but max_concurrent_arrays(1) should be
+    assert (
+        has_room is False
+    )  # courtesy_ceiling(500) not hit at 200, but max_concurrent_arrays(1) should be
     assert "max_concurrent_arrays" in reason
 
 
@@ -273,8 +289,11 @@ def test_max_concurrent_arrays_ignores_non_ramanbench_jobs(scheduler):
     )
     with patch("subprocess.run", side_effect=fake_run):
         has_room, reason = scheduler.check_capacity(
-            {"partition": "Debug_node"}, min_idle_cpus=32, courtesy_ceiling=200,
-            max_pending=50, max_concurrent_arrays=1,
+            {"partition": "Debug_node"},
+            min_idle_cpus=32,
+            courtesy_ceiling=200,
+            max_pending=50,
+            max_concurrent_arrays=1,
         )
     assert has_room is True
 
@@ -283,7 +302,9 @@ def test_run_tick_threads_max_concurrent_arrays_from_scope(scheduler, monkeypatc
     captured = {}
 
     def fake_check_capacity(
-        profile, min_idle_cpus, courtesy_ceiling,
+        profile,
+        min_idle_cpus,
+        courtesy_ceiling,
         max_pending=scheduler.DEFAULT_MAX_PENDING,
         max_concurrent_arrays=scheduler.DEFAULT_MAX_CONCURRENT_ARRAYS,
     ):
@@ -291,16 +312,21 @@ def test_run_tick_threads_max_concurrent_arrays_from_scope(scheduler, monkeypatc
         return False, "stopped for test"
 
     monkeypatch.setattr(
-        scheduler, "compute_backlog",
+        scheduler,
+        "compute_backlog",
         lambda scope, profile, **kwargs: {"PLS": [("wheat_lines", 0, 0, 0, 0, 10)]},
     )
     monkeypatch.setattr(scheduler, "check_capacity", fake_check_capacity)
 
     scope = {
-        "name": "test", "results_dir": "results", "n_splits": 3,
+        "name": "test",
+        "results_dir": "results",
+        "n_splits": 3,
         "max_concurrent_arrays": 3,
     }
-    scheduler.run_tick(scope, {"slurm": True, "partition": "Debug_node"}, log_path=None, dry_run=True)
+    scheduler.run_tick(
+        scope, {"slurm": True, "partition": "Debug_node"}, log_path=None, dry_run=True
+    )
 
     assert captured["max_concurrent_arrays"] == 3
 
@@ -312,7 +338,9 @@ def test_run_tick_threads_max_pending_from_scope(scheduler, monkeypatch):
     captured = {}
 
     def fake_check_capacity(
-        profile, min_idle_cpus, courtesy_ceiling,
+        profile,
+        min_idle_cpus,
+        courtesy_ceiling,
         max_pending=scheduler.DEFAULT_MAX_PENDING,
         max_concurrent_arrays=scheduler.DEFAULT_MAX_CONCURRENT_ARRAYS,
     ):
@@ -320,15 +348,20 @@ def test_run_tick_threads_max_pending_from_scope(scheduler, monkeypatch):
         return False, "stopped for test"
 
     monkeypatch.setattr(
-        scheduler, "compute_backlog",
+        scheduler,
+        "compute_backlog",
         lambda scope, profile, **kwargs: {"PLS": [("wheat_lines", 0, 0, 0, 0, 10)]},
     )
     monkeypatch.setattr(scheduler, "check_capacity", fake_check_capacity)
 
     scope = {
-        "name": "test", "results_dir": "results", "n_splits": 3,
+        "name": "test",
+        "results_dir": "results",
+        "n_splits": 3,
         "max_pending": 7,
     }
-    scheduler.run_tick(scope, {"slurm": True, "partition": "Debug_node"}, log_path=None, dry_run=True)
+    scheduler.run_tick(
+        scope, {"slurm": True, "partition": "Debug_node"}, log_path=None, dry_run=True
+    )
 
     assert captured["max_pending"] == 7

--- a/tests/test_generate_tabarena_foundation_models.py
+++ b/tests/test_generate_tabarena_foundation_models.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("tabarena")
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # TABFM/TABPFN-V3/TABSWIFT wrap an upstream ConfigGenerator with an empty search

--- a/tests/test_generate_tabarena_foundation_models_batch3.py
+++ b/tests/test_generate_tabarena_foundation_models_batch3.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("tabarena")
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # NORI, SAP_RPT_OSS, ORIONMSP, and LIMIX all wrap an upstream ConfigGenerator with

--- a/tests/test_generate_tabarena_models.py
+++ b/tests/test_generate_tabarena_models.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("tabarena")
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # Keys with an empty upstream search space (see generate/dummy.py,

--- a/tests/test_generate_tabarena_tree_models.py
+++ b/tests/test_generate_tabarena_tree_models.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("tabarena")
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # PERPETUAL_BOOSTER's upstream search space is a single categorical knob

--- a/tests/test_gpu_chunk_size.py
+++ b/tests/test_gpu_chunk_size.py
@@ -94,7 +94,8 @@ def test_run_tick_reads_gpu_chunk_size_from_scope(scheduler, monkeypatch):
         return real_pick_chunk(backlog, chunk_size, gpu_chunk_size)
 
     monkeypatch.setattr(
-        scheduler, "compute_backlog",
+        scheduler,
+        "compute_backlog",
         lambda scope, profile, **kwargs: {"NN_TORCH": _jobs(300)},
     )
     monkeypatch.setattr(scheduler, "check_capacity", lambda *a, **k: (True, "room"))
@@ -102,10 +103,15 @@ def test_run_tick_reads_gpu_chunk_size_from_scope(scheduler, monkeypatch):
     monkeypatch.setattr(scheduler, "pick_chunk", spy_pick_chunk)
 
     scope = {
-        "name": "test", "results_dir": "results", "n_splits": 3,
-        "models": ["NN_TORCH"], "gpu_chunk_size": 16,
+        "name": "test",
+        "results_dir": "results",
+        "n_splits": 3,
+        "models": ["NN_TORCH"],
+        "gpu_chunk_size": 16,
     }
-    scheduler.run_tick(scope, {"slurm": True, "partition": "Debug_node"}, log_path=None, dry_run=True)
+    scheduler.run_tick(
+        scope, {"slurm": True, "partition": "Debug_node"}, log_path=None, dry_run=True
+    )
 
     assert captured["gpu_chunk_size"] == 16
 
@@ -119,7 +125,8 @@ def test_run_tick_gpu_chunk_size_defaults_when_omitted(scheduler, monkeypatch):
         return real_pick_chunk(backlog, chunk_size, gpu_chunk_size)
 
     monkeypatch.setattr(
-        scheduler, "compute_backlog",
+        scheduler,
+        "compute_backlog",
         lambda scope, profile, **kwargs: {"NN_TORCH": _jobs(300)},
     )
     monkeypatch.setattr(scheduler, "check_capacity", lambda *a, **k: (True, "room"))
@@ -127,6 +134,8 @@ def test_run_tick_gpu_chunk_size_defaults_when_omitted(scheduler, monkeypatch):
     monkeypatch.setattr(scheduler, "pick_chunk", spy_pick_chunk)
 
     scope = {"name": "test", "results_dir": "results", "n_splits": 3, "models": ["NN_TORCH"]}
-    scheduler.run_tick(scope, {"slurm": True, "partition": "Debug_node"}, log_path=None, dry_run=True)
+    scheduler.run_tick(
+        scope, {"slurm": True, "partition": "Debug_node"}, log_path=None, dry_run=True
+    )
 
     assert captured["gpu_chunk_size"] == scheduler.DEFAULT_GPU_CHUNK_SIZE

--- a/tests/test_grouped_split.py
+++ b/tests/test_grouped_split.py
@@ -39,8 +39,7 @@ def test_split_is_stable_across_hash_seeds():
 
     Runs in subprocesses because PYTHONHASHSEED is fixed at interpreter start.
     """
-    prog = textwrap.dedent(
-        """
+    prog = textwrap.dedent("""
         import numpy as np, pandas as pd
         from raman_bench.benchmark import RamanBenchmark
         rng = np.random.RandomState(0)
@@ -50,8 +49,7 @@ def test_split_is_stable_across_hash_seeds():
         b.test_size, b.random_state = 0.34, 0
         _, te = b._grouped_train_test_split(df, group_by_df=df)
         print(sorted(te.index.tolist()))
-        """
-    )
+        """)
     outs = set()
     for seed in ("1", "2", "3", "4", "5"):
         r = subprocess.run(
@@ -73,9 +71,9 @@ def test_replicates_never_span_train_and_test():
         _, test = _bench(random_state=random_state)._grouped_train_test_split(df, group_by_df=df)
         in_test = set(test.index)
         for lo, hi in pairs:
-            assert (lo in in_test) == (hi in in_test), (
-                f"replicate pair ({lo},{hi}) split across partitions at seed {random_state}"
-            )
+            assert (lo in in_test) == (
+                hi in in_test
+            ), f"replicate pair ({lo},{hi}) split across partitions at seed {random_state}"
 
 
 def test_random_state_still_varies_the_split():

--- a/tests/test_metrics_no_delete.py
+++ b/tests/test_metrics_no_delete.py
@@ -45,8 +45,7 @@ def test_source_has_no_os_remove_of_predictions():
     offenders = [
         line.strip()
         for line in body.splitlines()
-        if not line.strip().startswith("#")
-        and re.search(r"os\.remove\s*\(\s*pred_path", line)
+        if not line.strip().startswith("#") and re.search(r"os\.remove\s*\(\s*pred_path", line)
     ]
     assert not offenders, (
         "compute_metrics_from_predictions deletes predictions again: "
@@ -66,8 +65,9 @@ def test_mismatched_prediction_is_kept_on_disk(tmp_path):
     pred_dir.mkdir(parents=True)
 
     # Same row count, different rows -> exactly the grouped-split failure mode.
-    path = _write_pair(pred_dir, "some_dataset_0", "CAT",
-                       gt_index=[0, 1, 2, 3], pred_index=[4, 5, 6, 7])
+    path = _write_pair(
+        pred_dir, "some_dataset_0", "CAT", gt_index=[0, 1, 2, 3], pred_index=[4, 5, 6, 7]
+    )
     assert path.exists()
 
     gt = pd.read_csv(pred_dir / "some_dataset_0_ground_truth.csv", index_col=0).sort_index()

--- a/tests/test_per_task_time_limit.py
+++ b/tests/test_per_task_time_limit.py
@@ -105,14 +105,19 @@ def test_resolve_time_limit_dataset_override_does_not_leak_to_other_datasets(sub
 
 def test_resolve_time_limit_model_override_applies(submit_job):
     assert (
-        submit_job.resolve_time_limit(3600, "microgel_synthesis", None, {"microgel_synthesis": 10800})
+        submit_job.resolve_time_limit(
+            3600, "microgel_synthesis", None, {"microgel_synthesis": 10800}
+        )
         == 10800
     )
 
 
 def test_resolve_time_limit_combines_both_sources(submit_job):
     value = submit_job.resolve_time_limit(
-        3600, "mlrod", {"mlrod": 10800}, {"mlrod": 7200},
+        3600,
+        "mlrod",
+        {"mlrod": 10800},
+        {"mlrod": 7200},
     )
     assert value == 10800  # larger of the two applicable overrides wins
 
@@ -147,7 +152,9 @@ def _read_jobspec_lines(path: Path) -> list[list[str]]:
         return [line.split() for line in f if line.strip()]
 
 
-def test_write_jobspec_per_task_time_limit_differs_within_one_chunk(submit_job, tmp_path, monkeypatch):
+def test_write_jobspec_per_task_time_limit_differs_within_one_chunk(
+    submit_job, tmp_path, monkeypatch
+):
     """Direct regression test for the reported live bug: a chunk mixing an
     mlrod-class task with a fast-dataset task must produce DIFFERENT
     time_limit fields for each -- not one inflated value shared by both."""
@@ -158,7 +165,8 @@ def test_write_jobspec_per_task_time_limit_differs_within_one_chunk(submit_job, 
         ("alzheimer", 0, 0, 1, 0, 10),
     ]
     path = submit_job.write_jobspec(
-        jobs, f"test_{uuid.uuid4().hex}",
+        jobs,
+        f"test_{uuid.uuid4().hex}",
         default_time_limit=3600,
         dataset_time_limit_overrides={"mlrod": 10800},
     )
@@ -186,7 +194,9 @@ def test_write_jobspec_no_overrides_uses_flat_default_everywhere(submit_job, tmp
 #     max(ceiling, ...) can never fall back below the ceiling). ---
 
 
-def test_submit_jobs_chunk_ceiling_does_not_leak_into_per_task_baseline(submit_job, tmp_path, monkeypatch):
+def test_submit_jobs_chunk_ceiling_does_not_leak_into_per_task_baseline(
+    submit_job, tmp_path, monkeypatch
+):
     """Mirrors exactly how opportunistic_scheduler.run_tick calls submit_jobs:
     `time_limit` is the whole-chunk ceiling (as effective_time_limit would
     return for a chunk containing mlrod -- 10800), while `default_time_limit`
@@ -203,14 +213,21 @@ def test_submit_jobs_chunk_ceiling_does_not_leak_into_per_task_baseline(submit_j
     slug = f"test_{uuid.uuid4().hex}"
 
     job_ids = submit_job.submit_jobs(
-        model="CAT", jobs=chunk, slug=slug,
-        n_splits=3, num_random_configs=50, num_bag_folds=8,
+        model="CAT",
+        jobs=chunk,
+        slug=slug,
+        n_splits=3,
+        num_random_configs=50,
+        num_bag_folds=8,
         time_limit=10800,  # whole-chunk ceiling (effective_time_limit's output)
         default_time_limit=3600,  # flat scope default (the fix under test)
         dataset_time_limit_overrides={"mlrod": 10800},
-        results_dir="results/v1/data", cache_dir=".cache_v1",
+        results_dir="results/v1/data",
+        cache_dir=".cache_v1",
         mirror_repo="HTW-KI-Werkstatt/RamanBench",
-        profile=profile, throttle=8, dry_run=True,
+        profile=profile,
+        throttle=8,
+        dry_run=True,
     )
     assert job_ids == []  # dry run -- nothing actually submitted
 
@@ -235,12 +252,19 @@ def test_submit_jobs_default_time_limit_falls_back_to_time_limit(submit_job, tmp
     slug = f"test_{uuid.uuid4().hex}"
 
     submit_job.submit_jobs(
-        model="PLS", jobs=jobs, slug=slug,
-        n_splits=3, num_random_configs=50, num_bag_folds=8,
+        model="PLS",
+        jobs=jobs,
+        slug=slug,
+        n_splits=3,
+        num_random_configs=50,
+        num_bag_folds=8,
         time_limit=3600,
-        results_dir="results/v1/data", cache_dir=".cache_v1",
+        results_dir="results/v1/data",
+        cache_dir=".cache_v1",
         mirror_repo="HTW-KI-Werkstatt/RamanBench",
-        profile=profile, throttle=8, dry_run=True,
+        profile=profile,
+        throttle=8,
+        dry_run=True,
     )
     lines = _read_jobspec_lines(tmp_path / f"{slug}.txt")
     assert all(parts[6] == "3600" for parts in lines)
@@ -251,7 +275,9 @@ def test_submit_jobs_default_time_limit_falls_back_to_time_limit(submit_job, tmp
 #     6-field jobspec on disk that this dedup logic still needs to read. ---
 
 
-def test_in_flight_targets_parses_both_6_and_7_field_jobspecs(opportunistic_scheduler, tmp_path, monkeypatch):
+def test_in_flight_targets_parses_both_6_and_7_field_jobspecs(
+    opportunistic_scheduler, tmp_path, monkeypatch
+):
     monkeypatch.setattr(opportunistic_scheduler, "JOBSPEC_DIR", tmp_path)
 
     old_format_path = tmp_path / "old_part.txt"

--- a/tests/test_preprocessing_ensemble.py
+++ b/tests/test_preprocessing_ensemble.py
@@ -11,8 +11,11 @@ AutoGluon model class.
 """
 
 import numpy as np
+import pytest
 
-from raman_bench.preprocessing.mixin import RamanPreprocessingMixin
+pytest.importorskip("autogluon")
+
+from raman_bench.preprocessing.mixin import RamanPreprocessingMixin  # noqa: E402
 
 
 class _FakeModel(RamanPreprocessingMixin):

--- a/tests/test_preprocessing_gcu_lvse.py
+++ b/tests/test_preprocessing_gcu_lvse.py
@@ -9,8 +9,11 @@ see the composition-order design note in mixin.py's _preprocess_fit.
 """
 
 import numpy as np
+import pytest
 
-from raman_bench.preprocessing.mixin import RamanPreprocessingMixin
+pytest.importorskip("autogluon")
+
+from raman_bench.preprocessing.mixin import RamanPreprocessingMixin  # noqa: E402
 
 
 class _FakeModel(RamanPreprocessingMixin):
@@ -87,9 +90,7 @@ def test_gcu_runs_after_shape_preserving_steps():
     """SNV enabled alongside GCU must run first (SNV output feeds GCU),
     not error, and not leave a stale n_features-wide representation."""
     X = _spectra(n_samples=10, n_features=30)
-    model = _FakeModel(
-        {"prep_snv_enabled": True, "prep_gcu_enabled": True, "prep_gcu_rho": 5}
-    )
+    model = _FakeModel({"prep_snv_enabled": True, "prep_gcu_enabled": True, "prep_gcu_rho": 5})
     out = model._preprocess_fit(X)
     assert out.shape == (10, 5)
 

--- a/tests/test_preprocessing_mixin_real_fit.py
+++ b/tests/test_preprocessing_mixin_real_fit.py
@@ -28,7 +28,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from raman_bench.preprocessing.wrapped_models import PREPROCESSED_MODELS
+pytest.importorskip("autogluon")
+
+from raman_bench.preprocessing.wrapped_models import PREPROCESSED_MODELS  # noqa: E402
 
 N_SAMPLES = 40
 N_FEATURES = 200

--- a/tests/test_preprocessing_mixin_shape.py
+++ b/tests/test_preprocessing_mixin_shape.py
@@ -7,7 +7,11 @@ DataFrame from the transformed array (see ``_output_feature_cols`` in
 ``mixin.py``, and the docstring caveat in ``crop_spectra``).
 """
 
-from raman_bench.preprocessing.mixin import _output_feature_cols
+import pytest
+
+pytest.importorskip("autogluon")
+
+from raman_bench.preprocessing.mixin import _output_feature_cols  # noqa: E402
 
 
 def test_output_feature_cols_unchanged_width():

--- a/tests/test_preprocessing_params.py
+++ b/tests/test_preprocessing_params.py
@@ -11,16 +11,23 @@ HPO or a model class's ``_set_default_params`` default.
 import pytest
 from raman_data import TASK_TYPE
 
-from raman_bench.config import _ALL_PREPROCESSING_STEPS, _normalize_preprocessing_params
-from raman_bench.model import AutoGluonModel
-from raman_bench.preprocessing.wrapped_models import PREPROCESSED_MODELS
+pytest.importorskip("autogluon")
+
+from raman_bench.config import (  # noqa: E402
+    _ALL_PREPROCESSING_STEPS,
+    _normalize_preprocessing_params,
+)
+from raman_bench.model import AutoGluonModel  # noqa: E402
+from raman_bench.preprocessing.wrapped_models import PREPROCESSED_MODELS  # noqa: E402
 
 
 def _prep_config(**enabled) -> dict:
     return {step: bool(enabled.get(step, False)) for step in _ALL_PREPROCESSING_STEPS}
 
 
-def _params_for(model: str, preprocessing_config=None, preprocessing_params=None, optimize=False) -> dict:
+def _params_for(
+    model: str, preprocessing_config=None, preprocessing_params=None, optimize=False
+) -> dict:
     m = AutoGluonModel(
         models=[model],
         ensemble=False,

--- a/tests/test_ramanpfn_real_fit.py
+++ b/tests/test_ramanpfn_real_fit.py
@@ -16,7 +16,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from raman_bench.preprocessing.wrapped_models import PREPROCESSED_MODELS
+pytest.importorskip("autogluon")
+
+from raman_bench.preprocessing.wrapped_models import PREPROCESSED_MODELS  # noqa: E402
 
 N_SAMPLES = 40
 N_FEATURES = 120

--- a/tests/test_resource_tuning_fixes.py
+++ b/tests/test_resource_tuning_fixes.py
@@ -56,6 +56,8 @@ from unittest.mock import patch
 
 import pytest
 
+pytest.importorskip("tabarena")
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -105,15 +107,11 @@ def test_ebm_interactions_disabled_for_wide_features():
     def _make_model(n_features: int) -> tuple[Prep_EBM, pd.DataFrame, pd.Series]:
         model = Prep_EBM(problem_type="regression")
         model.params = {}
-        X = pd.DataFrame(
-            {f"f{i}": [0.0, 1.0] for i in range(n_features)}
-        )
+        X = pd.DataFrame({f"f{i}": [0.0, 1.0] for i in range(n_features)})
         y = pd.Series([0.0, 1.0])
         return model, X, y
 
-    with patch(
-        "raman_bench.preprocessing.wrapped_models.EBMModel._fit", return_value=None
-    ):
+    with patch("raman_bench.preprocessing.wrapped_models.EBMModel._fit", return_value=None):
         wide_model, wide_x, wide_y = _make_model(_EBM_WIDE_FEATURE_THRESHOLD + 1)
         wide_model._fit(wide_x, wide_y)
         assert wide_model.params["interactions"] == 0
@@ -139,9 +137,7 @@ def test_ebm_interactions_not_reset_if_user_disabled_already():
     X = pd.DataFrame({f"f{i}": [0.0, 1.0] for i in range(n_features)})
     y = pd.Series([0.0, 1.0])
 
-    with patch(
-        "raman_bench.preprocessing.wrapped_models.EBMModel._fit", return_value=None
-    ):
+    with patch("raman_bench.preprocessing.wrapped_models.EBMModel._fit", return_value=None):
         model._fit(X, y)
     assert model.params["interactions"] == 0
 
@@ -199,16 +195,29 @@ def test_effective_time_limit_combines_both_override_sources(opportunistic_sched
     assert opportunistic_scheduler.effective_time_limit(scope, "EBM", chunk) == 10800
 
 
-def test_effective_time_limit_model_override_scalar_applies_regardless_of_dataset(opportunistic_scheduler):
+def test_effective_time_limit_model_override_scalar_applies_regardless_of_dataset(
+    opportunistic_scheduler,
+):
     """A model_time_limit_overrides entry may be a bare number instead of a
     dataset-keyed dict -- a blanket override for a model that's fast/
     deterministic enough that no time cap bounds anything meaningful (LR:
     no per-dataset variation, just don't cap it at all)."""
     scope = {"time_limit": 3600, "model_time_limit_overrides": {"LR": 800000}}
-    assert opportunistic_scheduler.effective_time_limit(scope, "LR", [("wheat_lines", 0, 0, 0, 0, 10)]) == 800000
-    assert opportunistic_scheduler.effective_time_limit(scope, "LR", [("alzheimer", 0, 0, 0, 0, 10)]) == 800000
+    assert (
+        opportunistic_scheduler.effective_time_limit(scope, "LR", [("wheat_lines", 0, 0, 0, 0, 10)])
+        == 800000
+    )
+    assert (
+        opportunistic_scheduler.effective_time_limit(scope, "LR", [("alzheimer", 0, 0, 0, 0, 10)])
+        == 800000
+    )
     # Another model without a scalar entry is unaffected.
-    assert opportunistic_scheduler.effective_time_limit(scope, "PLS", [("wheat_lines", 0, 0, 0, 0, 10)]) == 3600
+    assert (
+        opportunistic_scheduler.effective_time_limit(
+            scope, "PLS", [("wheat_lines", 0, 0, 0, 0, 10)]
+        )
+        == 3600
+    )
 
 
 def test_effective_time_limit_no_overrides(opportunistic_scheduler):
@@ -261,9 +270,7 @@ def test_run_one_skips_classification_only_model_on_regression_dataset(run_exper
     df = _make_df(n_features=10)
     fake = _FakeDataset(TASK_TYPE.Regression, df)
 
-    with patch(
-        "raman_bench.benchmark.RamanBenchmark._load_raman_dataset", return_value=fake
-    ):
+    with patch("raman_bench.benchmark.RamanBenchmark._load_raman_dataset", return_value=fake):
         out = run_experiment.run_one(
             dataset_name="fake_dataset",
             target_idx=0,
@@ -281,9 +288,7 @@ def test_run_one_skips_regression_only_model_on_classification_dataset(run_exper
     df = _make_df(n_features=10)
     fake = _FakeDataset(TASK_TYPE.Classification, df)
 
-    with patch(
-        "raman_bench.benchmark.RamanBenchmark._load_raman_dataset", return_value=fake
-    ):
+    with patch("raman_bench.benchmark.RamanBenchmark._load_raman_dataset", return_value=fake):
         out = run_experiment.run_one(
             dataset_name="fake_dataset",
             target_idx=0,
@@ -350,9 +355,7 @@ def test_run_one_skips_orionmsp_above_vram_budget(run_experiment):
     df = _make_df(n_features=5000, n_rows=700)
     fake = _FakeDataset(TASK_TYPE.Classification, df)
 
-    with patch(
-        "raman_bench.benchmark.RamanBenchmark._load_raman_dataset", return_value=fake
-    ):
+    with patch("raman_bench.benchmark.RamanBenchmark._load_raman_dataset", return_value=fake):
         out = run_experiment.run_one(
             dataset_name="fake_wide_and_tall_dataset",
             target_idx=0,
@@ -389,12 +392,8 @@ def test_run_one_does_not_skip_orionmsp_below_vram_budget(run_experiment):
         raise RuntimeError("stop before any real (CUDA/CPU) model work")
 
     with (
-        patch(
-            "raman_bench.benchmark.RamanBenchmark._load_raman_dataset", return_value=fake
-        ),
-        patch(
-            "raman_bench.preprocessing.wrapped_models.OrionMSPModel._fit", _fake_fit
-        ),
+        patch("raman_bench.benchmark.RamanBenchmark._load_raman_dataset", return_value=fake),
+        patch("raman_bench.preprocessing.wrapped_models.OrionMSPModel._fit", _fake_fit),
         pytest.raises(RuntimeError, match="stop before any real"),
     ):
         run_experiment.run_one(
@@ -427,9 +426,7 @@ def test_run_one_skips_tabstar_above_max_features(run_experiment):
     df = _make_df(n_features=n_features, n_rows=4)
     fake = _FakeDataset(TASK_TYPE.Regression, df)
 
-    with patch(
-        "raman_bench.benchmark.RamanBenchmark._load_raman_dataset", return_value=fake
-    ):
+    with patch("raman_bench.benchmark.RamanBenchmark._load_raman_dataset", return_value=fake):
         out = run_experiment.run_one(
             dataset_name="fake_wide_dataset",
             target_idx=0,

--- a/tests/test_splitting.py
+++ b/tests/test_splitting.py
@@ -12,7 +12,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from raman_bench.splitting import (
+pytest.importorskip("tabarena")
+
+from raman_bench.splitting import (  # noqa: E402
     GROUP_COL,
     RamanBenchTaskWrapper,
     TooFewClassesError,
@@ -41,8 +43,12 @@ def test_grouped_classification_no_leakage_across_repeats_and_folds():
     df = _grouped_dataset(problem_type="classification")
     n_repeats, n_splits = 2, 3
     _, task_obj = build_user_task(
-        task_name="test_grouped_clf", df=df, label_col="target",
-        problem_type="classification", n_repeats=n_repeats, n_splits=n_splits,
+        task_name="test_grouped_clf",
+        df=df,
+        label_col="target",
+        problem_type="classification",
+        n_repeats=n_repeats,
+        n_splits=n_splits,
     )
     wrapper = RamanBenchTaskWrapper(task=task_obj)
     for repeat in range(n_repeats):
@@ -58,8 +64,12 @@ def test_grouped_classification_no_leakage_across_repeats_and_folds():
 def test_grouped_regression_no_leakage():
     df = _grouped_dataset(problem_type="regression")
     _, task_obj = build_user_task(
-        task_name="test_grouped_reg", df=df, label_col="target",
-        problem_type="regression", n_repeats=2, n_splits=3,
+        task_name="test_grouped_reg",
+        df=df,
+        label_col="target",
+        problem_type="regression",
+        n_repeats=2,
+        n_splits=3,
     )
     wrapper = RamanBenchTaskWrapper(task=task_obj)
     for repeat in range(2):
@@ -78,8 +88,12 @@ def test_group_id_column_always_stripped_from_features():
     """
     df = _grouped_dataset(problem_type="regression")
     _, task_obj = build_user_task(
-        task_name="test_strip", df=df, label_col="target",
-        problem_type="regression", n_repeats=1, n_splits=3,
+        task_name="test_strip",
+        df=df,
+        label_col="target",
+        problem_type="regression",
+        n_repeats=1,
+        n_splits=3,
     )
     wrapper = RamanBenchTaskWrapper(task=task_obj)
     assert GROUP_COL not in wrapper.X.columns
@@ -96,8 +110,13 @@ def test_ungrouped_regression_fallback():
 
     n_splits = 5
     _, task_obj = build_user_task(
-        task_name="test_ungrouped_reg", df=df, label_col="target",
-        problem_type="regression", n_repeats=2, n_splits=n_splits, group_col=None,
+        task_name="test_ungrouped_reg",
+        df=df,
+        label_col="target",
+        problem_type="regression",
+        n_repeats=2,
+        n_splits=n_splits,
+        group_col=None,
     )
     wrapper = RamanBenchTaskWrapper(task=task_obj)
     for repeat in range(2):
@@ -114,8 +133,13 @@ def test_ungrouped_classification_fallback_is_stratified():
     df["target"] = rng.choice(["x", "y"], size=30, p=[0.6, 0.4])
 
     _, task_obj = build_user_task(
-        task_name="test_ungrouped_clf", df=df, label_col="target",
-        problem_type="classification", n_repeats=1, n_splits=3, group_col=None,
+        task_name="test_ungrouped_clf",
+        df=df,
+        label_col="target",
+        problem_type="classification",
+        n_repeats=1,
+        n_splits=3,
+        group_col=None,
     )
     wrapper = RamanBenchTaskWrapper(task=task_obj)
     X_tr, y_tr, X_te, y_te = wrapper.get_train_test_split(fold=0, repeat=0)
@@ -134,8 +158,13 @@ def test_repeats_produce_different_splits():
     df["target"] = X.iloc[:, 0] * 2 + rng.randn(30) * 0.1
 
     _, task_obj = build_user_task(
-        task_name="test_repeats_differ", df=df, label_col="target",
-        problem_type="regression", n_repeats=2, n_splits=3, group_col=None,
+        task_name="test_repeats_differ",
+        df=df,
+        label_col="target",
+        problem_type="regression",
+        n_repeats=2,
+        n_splits=3,
+        group_col=None,
     )
     wrapper = RamanBenchTaskWrapper(task=task_obj)
     X_tr_r0, _, _, _ = wrapper.get_train_test_split(fold=0, repeat=0)
@@ -162,13 +191,15 @@ def test_filter_rare_classes_disabled_when_threshold_zero():
 
 
 def test_infer_group_ids_finds_real_replicates():
-    targets = np.array([
-        [1.5, 2.0],
-        [3.3, 0.0],
-        [1.5, 2.0],  # replicate of row 0
-        [9.9, 1.1],
-        [3.3, 0.0],  # replicate of row 1
-    ])
+    targets = np.array(
+        [
+            [1.5, 2.0],
+            [3.3, 0.0],
+            [1.5, 2.0],  # replicate of row 0
+            [9.9, 1.1],
+            [3.3, 0.0],  # replicate of row 1
+        ]
+    )
     group_ids = infer_group_ids_from_targets(targets)
     assert group_ids is not None
     assert group_ids[0] == group_ids[2]
@@ -202,7 +233,9 @@ def test_get_n_repeats_matches_tabarena_thresholds():
     assert get_n_repeats(748, tabarena_lite=True) == 1
 
 
-def _semi_supervised_dataset(n=50, n_unlabeled=15, problem_type="classification", grouped=False, seed=0):
+def _semi_supervised_dataset(
+    n=50, n_unlabeled=15, problem_type="classification", grouped=False, seed=0
+):
     rng = np.random.RandomState(seed)
     X = pd.DataFrame(rng.randn(n, 8), columns=[f"{100 + i * 5}" for i in range(8)])
     df = X.copy()
@@ -221,8 +254,13 @@ def _semi_supervised_dataset(n=50, n_unlabeled=15, problem_type="classification"
 def test_unlabeled_rows_never_in_test_ungrouped_classification():
     df = _semi_supervised_dataset(problem_type="classification", grouped=False)
     _, task_obj = build_user_task(
-        task_name="semi_clf", df=df, label_col="target",
-        problem_type="classification", n_repeats=2, n_splits=3, group_col=None,
+        task_name="semi_clf",
+        df=df,
+        label_col="target",
+        problem_type="classification",
+        n_repeats=2,
+        n_splits=3,
+        group_col=None,
     )
     wrapper = RamanBenchTaskWrapper(task=task_obj)
     for repeat in range(2):
@@ -235,8 +273,12 @@ def test_unlabeled_rows_never_in_test_ungrouped_classification():
 def test_unlabeled_rows_never_in_test_grouped_regression_no_group_leak():
     df = _semi_supervised_dataset(n=40, n_unlabeled=10, problem_type="regression", grouped=True)
     _, task_obj = build_user_task(
-        task_name="semi_reg_grouped", df=df, label_col="target",
-        problem_type="regression", n_repeats=2, n_splits=3,
+        task_name="semi_reg_grouped",
+        df=df,
+        label_col="target",
+        problem_type="regression",
+        n_repeats=2,
+        n_splits=3,
     )
     wrapper = RamanBenchTaskWrapper(task=task_obj)
     for repeat in range(2):

--- a/tests/test_stuck_task_detection.py
+++ b/tests/test_stuck_task_detection.py
@@ -87,13 +87,22 @@ def test_resolve_array_task_reads_correct_line(osched, tmp_path, monkeypatch):
         "wheat_lines 0 0 0 0 3 3600\nwheat_lines 0 0 1 0 3 3600\nbacteria_identification 0 0 0 0 3 3600\n"
     )
     assert osched._resolve_array_task("LR", "RB_LR_v1_default_LR_20260822T160705_0") == (
-        "wheat_lines", 0, 0, 0,
+        "wheat_lines",
+        0,
+        0,
+        0,
     )
     assert osched._resolve_array_task("LR", "RB_LR_v1_default_LR_20260822T160705_1") == (
-        "wheat_lines", 0, 0, 1,
+        "wheat_lines",
+        0,
+        0,
+        1,
     )
     assert osched._resolve_array_task("LR", "RB_LR_v1_default_LR_20260822T160705_2") == (
-        "bacteria_identification", 0, 0, 0,
+        "bacteria_identification",
+        0,
+        0,
+        0,
     )
 
 
@@ -241,11 +250,17 @@ def test_compute_backlog_excludes_stuck_tasks(osched, tmp_path, monkeypatch):
 
     results_dir = tmp_path / "results"
     targets_file = tmp_path / "target_list.json"
-    targets_file.write_text(json.dumps([
-        {"dataset": "wheat_lines", "target_idx": 0, "n_repeats": 1, "excluded": False},
-    ]))
+    targets_file.write_text(
+        json.dumps(
+            [
+                {"dataset": "wheat_lines", "target_idx": 0, "n_repeats": 1, "excluded": False},
+            ]
+        )
+    )
     scope = {
-        "results_dir": str(results_dir), "n_splits": 1, "targets_file": str(targets_file),
+        "results_dir": str(results_dir),
+        "n_splits": 1,
+        "targets_file": str(targets_file),
         "models": ["LR"],
     }
     profile = {}
@@ -254,9 +269,13 @@ def test_compute_backlog_excludes_stuck_tasks(osched, tmp_path, monkeypatch):
     jobspec_path.write_text("wheat_lines 0 0 0 0 1 3600\n")
     state_path = tmp_path / "failures.json"
     now = datetime.datetime.now().isoformat()
-    state_path.write_text(json.dumps({
-        "LR": {"wheat_lines|0|0|0": {"a": now, "b": now, "c": now}},
-    }))
+    state_path.write_text(
+        json.dumps(
+            {
+                "LR": {"wheat_lines|0|0|0": {"a": now, "b": now, "c": now}},
+            }
+        )
+    )
 
     with patch("subprocess.run", side_effect=_fake_sacct_run([])):
         backlog = osched.compute_backlog(scope, profile, failure_state_path=state_path)
@@ -264,7 +283,9 @@ def test_compute_backlog_excludes_stuck_tasks(osched, tmp_path, monkeypatch):
     assert backlog["LR"] == []
 
 
-def test_compute_backlog_without_failure_state_path_ignores_stuck_mechanism(osched, tmp_path, monkeypatch):
+def test_compute_backlog_without_failure_state_path_ignores_stuck_mechanism(
+    osched, tmp_path, monkeypatch
+):
     """Passing no failure_state_path (the default) must behave exactly as
     before this feature existed -- a persistently-failing task still shows up
     in the backlog, since nothing was told to track failures at all."""
@@ -275,11 +296,17 @@ def test_compute_backlog_without_failure_state_path_ignores_stuck_mechanism(osch
 
     results_dir = tmp_path / "results"
     targets_file = tmp_path / "target_list.json"
-    targets_file.write_text(json.dumps([
-        {"dataset": "wheat_lines", "target_idx": 0, "n_repeats": 1, "excluded": False},
-    ]))
+    targets_file.write_text(
+        json.dumps(
+            [
+                {"dataset": "wheat_lines", "target_idx": 0, "n_repeats": 1, "excluded": False},
+            ]
+        )
+    )
     scope = {
-        "results_dir": str(results_dir), "n_splits": 1, "targets_file": str(targets_file),
+        "results_dir": str(results_dir),
+        "n_splits": 1,
+        "targets_file": str(targets_file),
         "models": ["LR"],
     }
     profile = {}

--- a/tests/test_wrapped_models.py
+++ b/tests/test_wrapped_models.py
@@ -8,7 +8,11 @@ AutoGluon base class; the custom Raman/bridge-backed models needed them added
 explicitly.
 """
 
-from raman_bench.preprocessing.wrapped_models import PREPROCESSED_MODELS
+import pytest
+
+pytest.importorskip("autogluon")
+
+from raman_bench.preprocessing.wrapped_models import PREPROCESSED_MODELS  # noqa: E402
 
 
 def test_all_models_have_ag_key_and_ag_name():

--- a/tests/verify_full_benchmark.py
+++ b/tests/verify_full_benchmark.py
@@ -1,8 +1,8 @@
 """Verify that all datasets from the RamanBench paper can be loaded."""
 
-import tempfile
-import shutil
 import os
+import shutil
+import tempfile
 
 from raman_bench.benchmark import RamanBenchmark
 


### PR DESCRIPTION
## Summary
- Adds `pytest.importorskip("autogluon")` (or `"tabarena"` where that's the actual missing dependency) to the remaining test files that were failing CI on `main` after the `refactor/v1-tabarena` merge — including 4 files (`test_generate_tabarena_models.py`, `test_generate_tabarena_foundation_models{,_batch3}.py`, `test_resource_tuning_fixes.py`) where the missing import happens lazily inside a test body via `raman_bench.models.registry`'s own unconditional `from autogluon.tabular.registry import ModelRegistry`, not at collection time.
- Applies `black`/`isort` to clear the (non-blocking) format-check job.

## Test plan
- [x] Verified clean in a from-scratch venv mirroring CI's install steps (`pip install -e ".[dev]"` + CPU torch, no autogluon/tabarena)
- [x] `pytest tests/ -v --tb=short -x` → 158 passed, 46 skipped, 0 failed (matches CI's exact invocation)
- [x] `black --check --fast src/ tests/` and `isort --check src tests` both clean