### PR TITLE
Add dataset categorization axes (scale/dimensionality/split-type/imbalance)

### DIFF
--- a/src/raman_bench/dataset_categorization.py
+++ b/src/raman_bench/dataset_categorization.py
@@ -1,0 +1,178 @@
+"""Dataset categorization axes for RamanBench, following the sub-benchmark
+scheme in the BeyondArena paper (arXiv:2606.30410) -- split type (IID vs.
+grouped), scale (sample-count tier), and dimensionality (feature-count tier)
+-- plus additional axes that matter specifically for Raman spectroscopy
+benchmarking (class imbalance, single- vs. multi-target regression, and
+wavenumber coverage).
+
+Every threshold below is a plain module-level constant, calibrated against
+the actual 77-dataset ``v1_default`` roster (see the tuple docstrings) rather
+than copied verbatim from BeyondArena, because two of its thresholds are
+degenerate for Raman spectra:
+
+- BeyondArena's dimensionality split (low: <=100 columns, high: >100) puts
+  *every* RamanBench dataset in "high" -- the narrowest spectrum here still
+  has 114 wavenumber points. Recalibrated to three tiers spanning the real
+  114-11,689 feature range instead.
+- BeyondArena's smallest scale tier ("tiny") starts at 100 rows, but 25 of
+  RamanBench's 77 datasets have fewer than 100 samples (as few as 12) --
+  small-cohort spectroscopy studies are common in this domain in a way they
+  aren't in large-scale tabular benchmarking. Added a "micro" tier below
+  "tiny" to cover them, rather than leaving them uncategorized.
+
+BeyondArena's "text"/"high cardinality" feature-type axes have no Raman
+analogue (every feature is a continuous wavenumber intensity, never
+categorical/text), so they're intentionally not reproduced here. BeyondArena's
+"temporal" task type is also omitted -- RamanBench has no time-series-across-
+samples structure, only the IID/grouped distinction.
+
+This module is pure (no I/O, no dependency on ``raman_data`` types) so it can
+be unit-tested directly and reused anywhere a plain scalar dataset summary is
+available -- ``raman_bench_paper``'s dataset-stats cache calls
+:func:`categorize_dataset` once per dataset and merges the result in.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Scale (sample count) -- BeyondArena's tiny/small/medium/large thresholds,
+# with an added "micro" floor (see module docstring).
+# ---------------------------------------------------------------------------
+
+SCALE_TIERS = ("micro", "tiny", "small", "medium", "large")
+_SCALE_THRESHOLDS = (
+    100,
+    1_000,
+    10_000,
+    100_000,
+)  # upper-exclusive bounds for micro/tiny/small/medium
+
+
+def scale_tier(n_samples: int) -> str:
+    """micro (<100) / tiny (100-999) / small (1e3-1e4) / medium (1e4-1e5) / large (>=1e5)."""
+    for tier, bound in zip(SCALE_TIERS, _SCALE_THRESHOLDS):
+        if n_samples < bound:
+            return tier
+    return "large"
+
+
+# ---------------------------------------------------------------------------
+# Dimensionality (feature count) -- recalibrated for Raman spectra's real
+# range (114-11,689 wavenumber points across the v1_default roster).
+# ---------------------------------------------------------------------------
+
+DIMENSIONALITY_TIERS = ("low", "medium", "high")
+_DIM_THRESHOLDS = (1_000, 3_000)  # upper-exclusive bounds for low/medium
+
+
+def dimensionality_tier(n_features: int) -> str:
+    """low (<1000) / medium (1000-2999) / high (>=3000) wavenumber points."""
+    for tier, bound in zip(DIMENSIONALITY_TIERS, _DIM_THRESHOLDS):
+        if n_features < bound:
+            return tier
+    return "high"
+
+
+# ---------------------------------------------------------------------------
+# Split type -- IID vs. grouped, mirroring ``DatasetInfo.is_grouped``.
+# ---------------------------------------------------------------------------
+
+
+def split_type(is_grouped: bool | None) -> str:
+    """ "grouped" / "iid" / "unknown" (``is_grouped`` not yet determined)."""
+    if is_grouped is True:
+        return "grouped"
+    if is_grouped is False:
+        return "iid"
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Class imbalance (classification only) -- standard imbalance-ratio bins
+# (majority-class count / minority-class count).
+# ---------------------------------------------------------------------------
+
+IMBALANCE_TIERS = ("balanced", "moderate", "severe")
+_IMBALANCE_THRESHOLDS = (3.0, 10.0)  # upper-exclusive bounds for balanced/moderate
+
+
+def imbalance_tier(class_counts: list[int]) -> str:
+    """balanced (IR<3) / moderate (3<=IR<10) / severe (IR>=10).
+
+    IR (imbalance ratio) = majority-class count / minority-class count,
+    the standard measure in the imbalanced-classification literature.
+    """
+    if not class_counts or len(class_counts) < 2:
+        raise ValueError("imbalance_tier needs at least 2 classes' counts")
+    counts = [c for c in class_counts if c > 0]
+    ir = max(counts) / min(counts)
+    for tier, bound in zip(IMBALANCE_TIERS, _IMBALANCE_THRESHOLDS):
+        if ir < bound:
+            return tier
+    return "severe"
+
+
+# ---------------------------------------------------------------------------
+# Target arity -- single- vs. multi-target regression panels.
+# ---------------------------------------------------------------------------
+
+
+def target_arity(n_targets: int) -> str:
+    """ "single-target" (1 target column) vs. "multi-target" (>1)."""
+    return "single-target" if n_targets <= 1 else "multi-target"
+
+
+# ---------------------------------------------------------------------------
+# Wavenumber coverage -- informational only, not a difficulty axis. Whether
+# the measured range extends into the high-wavenumber C-H/O-H stretch region
+# (roughly >1800 cm^-1) or stays within the classic fingerprint region.
+# ---------------------------------------------------------------------------
+
+_FINGERPRINT_MAX = 1_800.0
+
+
+def wavenumber_coverage(freq_max: float) -> str:
+    """ "fingerprint" (max shift <=1800 cm^-1) vs. "extended" (>1800 cm^-1).
+
+    A rough heuristic, not a precise spectroscopic boundary -- informational
+    grouping only (which part of the spectrum was measured), not a claim
+    about task difficulty.
+    """
+    return "fingerprint" if freq_max <= _FINGERPRINT_MAX else "extended"
+
+
+# ---------------------------------------------------------------------------
+# Aggregator
+# ---------------------------------------------------------------------------
+
+
+def categorize_dataset(
+    *,
+    n_samples: int,
+    n_features: int,
+    n_targets: int,
+    is_grouped: bool | None = None,
+    freq_max: float | None = None,
+    class_counts: list[int] | None = None,
+) -> dict[str, str]:
+    """Compute every categorization axis for one dataset from its summary stats.
+
+    Parameters mirror the fields already collected by
+    ``raman_bench_paper/scripts/dataset_stats.py``'s per-dataset stats dict,
+    so callers can typically do ``categorize_dataset(**stats_subset)``.
+
+    ``class_counts`` (per-class sample counts) is optional -- pass it for
+    classification datasets to get ``imbalance_tier``; omitted (or ``None``)
+    for regression datasets, where it doesn't apply.
+    """
+    categories = {
+        "scale_tier": scale_tier(n_samples),
+        "dimensionality_tier": dimensionality_tier(n_features),
+        "split_type": split_type(is_grouped),
+        "target_arity": target_arity(n_targets),
+    }
+    if freq_max is not None:
+        categories["wavenumber_coverage"] = wavenumber_coverage(freq_max)
+    if class_counts is not None:
+        categories["imbalance_tier"] = imbalance_tier(class_counts)
+    return categories

--- a/tests/test_dataset_categorization.py
+++ b/tests/test_dataset_categorization.py
@@ -1,0 +1,168 @@
+"""Tests for raman_bench.dataset_categorization.
+
+Tier boundaries are checked exactly at their edges (upper-exclusive), and a
+handful of real datasets from the v1_default roster are used as sanity
+anchors so a future threshold change has to consciously update these too.
+"""
+
+import pytest
+
+from raman_bench.dataset_categorization import (
+    categorize_dataset,
+    dimensionality_tier,
+    imbalance_tier,
+    scale_tier,
+    split_type,
+    target_arity,
+    wavenumber_coverage,
+)
+
+# ---------------------------------------------------------------------------
+# scale_tier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "n_samples,expected",
+    [
+        (1, "micro"),
+        (99, "micro"),
+        (100, "tiny"),
+        (999, "tiny"),
+        (1_000, "small"),
+        (9_999, "small"),
+        (10_000, "medium"),
+        (99_999, "medium"),
+        (100_000, "large"),
+        (130_061, "large"),  # mlrod
+    ],
+)
+def test_scale_tier_boundaries(n_samples, expected):
+    assert scale_tier(n_samples) == expected
+
+
+def test_scale_tier_real_anchors():
+    assert scale_tier(90) == "micro"  # amino_acids_glycine
+    assert scale_tier(1151) == "small"  # alzheimer
+    assert scale_tier(53134) == "medium"  # wheat_lines
+
+
+# ---------------------------------------------------------------------------
+# dimensionality_tier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "n_features,expected",
+    [
+        (1, "low"),
+        (999, "low"),
+        (1_000, "medium"),
+        (2_999, "medium"),
+        (3_000, "high"),
+        (11_689, "high"),  # itaconic_acid_species
+    ],
+)
+def test_dimensionality_tier_boundaries(n_features, expected):
+    assert dimensionality_tier(n_features) == expected
+
+
+def test_dimensionality_tier_real_anchors():
+    assert dimensionality_tier(114) == "low"  # tg_ecoli_fermentation
+    assert dimensionality_tier(885) == "low"  # alzheimer
+    assert dimensionality_tier(1870) == "medium"  # bioprocess_substrates
+
+
+# ---------------------------------------------------------------------------
+# split_type
+# ---------------------------------------------------------------------------
+
+
+def test_split_type():
+    assert split_type(True) == "grouped"
+    assert split_type(False) == "iid"
+    assert split_type(None) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# imbalance_tier
+# ---------------------------------------------------------------------------
+
+
+def test_imbalance_tier_balanced():
+    assert imbalance_tier([50, 50]) == "balanced"
+    assert imbalance_tier([100, 50]) == "balanced"  # IR=2 < 3
+
+
+def test_imbalance_tier_moderate():
+    assert imbalance_tier([100, 20]) == "moderate"  # IR=5
+
+
+def test_imbalance_tier_severe():
+    assert imbalance_tier([1000, 20]) == "severe"  # IR=50
+
+
+def test_imbalance_tier_multiclass_uses_extremes():
+    assert imbalance_tier([500, 100, 90, 5]) == "severe"  # IR=100
+
+
+def test_imbalance_tier_requires_at_least_two_classes():
+    with pytest.raises(ValueError):
+        imbalance_tier([100])
+
+
+# ---------------------------------------------------------------------------
+# target_arity
+# ---------------------------------------------------------------------------
+
+
+def test_target_arity():
+    assert target_arity(1) == "single-target"
+    assert target_arity(2) == "multi-target"
+    assert target_arity(12) == "multi-target"
+
+
+# ---------------------------------------------------------------------------
+# wavenumber_coverage
+# ---------------------------------------------------------------------------
+
+
+def test_wavenumber_coverage():
+    assert wavenumber_coverage(1800) == "fingerprint"
+    assert wavenumber_coverage(1799) == "fingerprint"
+    assert wavenumber_coverage(1801) == "extended"
+    assert wavenumber_coverage(3000) == "extended"
+
+
+# ---------------------------------------------------------------------------
+# categorize_dataset (aggregator)
+# ---------------------------------------------------------------------------
+
+
+def test_categorize_dataset_regression_no_class_counts():
+    result = categorize_dataset(
+        n_samples=6960, n_features=1870, n_targets=1, is_grouped=False, freq_max=1900.0
+    )
+    assert result == {
+        "scale_tier": "small",
+        "dimensionality_tier": "medium",
+        "split_type": "iid",
+        "target_arity": "single-target",
+        "wavenumber_coverage": "extended",
+    }
+    assert "imbalance_tier" not in result
+
+
+def test_categorize_dataset_classification_with_class_counts():
+    result = categorize_dataset(
+        n_samples=1151,
+        n_features=885,
+        n_targets=1,
+        is_grouped=None,
+        class_counts=[600, 551],
+    )
+    assert result["scale_tier"] == "small"
+    assert result["dimensionality_tier"] == "low"
+    assert result["split_type"] == "unknown"
+    assert result["imbalance_tier"] == "balanced"
+    assert "wavenumber_coverage" not in result


### PR DESCRIPTION
## Summary

Implements the BeyondArena paper's (arXiv:2606.30410) sub-benchmark categorization
scheme -- split type (IID vs. grouped), scale tier, dimensionality tier -- plus axes
specific to Raman spectroscopy benchmarking that the generic tabular scheme doesn't
cover: class imbalance tier, single- vs. multi-target regression, and wavenumber
coverage.

Thresholds are recalibrated against the real 77-dataset `v1_default` roster rather
than copied verbatim, because two of BeyondArena's thresholds are degenerate for
Raman spectra:
- Its dimensionality split (low <=100 columns) would put *every* RamanBench dataset
  in "high" -- the narrowest spectrum here has 114 wavenumber points.
- Its smallest scale tier (>=100 rows) leaves 25 of the 77 datasets -- some as small
  as 12 samples, common for small-cohort spectroscopy studies -- uncategorized below
  the floor. Added a "micro" tier below "tiny" to cover them.

Pure functions, no I/O, no dependency on `raman_data` types -- reusable anywhere a
plain scalar dataset summary is available. Already wired into `raman_bench_paper`'s
dataset-stats cache to produce an appendix table (separate, private-repo change).

## Test plan
- [x] `pytest tests/test_dataset_categorization.py` -- 28 passed
- [x] Verified end-to-end against real dataset stats (v1_default roster) via the
      paper repo's `dataset_stats.py` integration
- [x] black/isort/ruff clean