### PR TITLE
README: de-slop the prose, fix stale facts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing to RamanBench
 
-Thank you for your interest in contributing!  This guide covers two main contribution paths:
+This guide covers the two contribution paths:
 
-1. **[Adding a new model](#adding-a-new-model)** — wrap an existing AutoGluon model or implement a new one
-2. **[Adding a new dataset](#adding-a-new-dataset)** — contribute a new Raman spectroscopy dataset
+1. **[Adding a new model](#adding-a-new-model)** — wrap an existing AutoGluon model, or implement a new one
+2. **[Adding a new dataset](#adding-a-new-dataset)** — contribute a Raman spectroscopy dataset
 
 For bug reports and feature requests, please open an issue on
 [GitHub](https://github.com/ml-lab-htw/RamanBench/issues).
@@ -18,7 +18,7 @@ Before you start, here are the key resources:
 |---------------------------------|----------------------------------------------------------------------------------------------------|
 | **raman-data** (dataset loader) | [GitHub](https://github.com/ml-lab-htw/raman_data) · [PyPI](https://pypi.org/project/raman-data/)  |
 | **raman-bench** (this repo)     | [GitHub](https://github.com/ml-lab-htw/RamanBench) · [PyPI](https://pypi.org/project/raman-bench/) |
-| **Live Leaderboard**            | [huggingface.co/spaces/ml-lab-htw/RamanBench](https://huggingface.co/spaces/HTW-KI-Werkstatt/RamanBench) |
+| **Live Leaderboard**            | [huggingface.co/spaces/HTW-KI-Werkstatt/RamanBench](https://huggingface.co/spaces/HTW-KI-Werkstatt/RamanBench) |
 | **Paper**                       | [arXiv:2605.02003](https://arxiv.org/abs/2605.02003)                                                             |
 
 ---

--- a/README.md
+++ b/README.md
@@ -7,15 +7,14 @@
 [![arXiv](https://img.shields.io/badge/arXiv-2605.02003-b31b1b)](https://arxiv.org/abs/2605.02003)
 [![Leaderboard](https://img.shields.io/badge/🏆_Leaderboard-HuggingFace-orange)](https://huggingface.co/spaces/HTW-KI-Werkstatt/RamanBench)
 
-**A large-scale benchmark for machine learning on Raman spectroscopy data.**
+**A machine-learning benchmark for Raman spectroscopy.**
 
-> 74 datasets · 163 prediction targets · 28 baseline models · 4 application domains
-
-RamanBench provides a reproducible evaluation protocol and a curated collection
-of public Raman spectroscopy datasets spanning Material Science, Biological,
-Medical, and Chemical applications.  Researchers can rank new models against
-28 pre-evaluated baselines — from classical PLS to tabular foundation models
-and Raman-specific deep learning architectures — without re-running all experiments.
+RamanBench collects 74 public Raman datasets (163 prediction targets, four
+application domains: Material Science, Biological, Medical, Chemical) behind one
+evaluation protocol, and ships the results of 28 baseline models run through it.
+You can score a new model against those baselines without re-running the
+experiments. The baselines cover classical chemometrics, gradient boosting,
+tabular foundation models, and deep networks built for spectra.
 
 ---
 
@@ -44,16 +43,15 @@ PyPI / GitHub     PyPI / GitHub
 pip install raman-bench
 ```
 
-This gives you:
+This is enough to:
 
-- **All 74 datasets** with standardised train/test splits via `raman-data`
-- **Precomputed results** for 28 baseline models (bundled CSVs, no internet needed)
-- **Leaderboard API** — rank, plot, and compare against baselines
-- **Evaluation API** — `lb.evaluate_and_add(model)` works with *any* sklearn-compatible model
+- load all 74 datasets with fixed train/test splits (via `raman-data`)
+- read the precomputed results for the 28 baselines (bundled CSVs, works offline)
+- score your own model against them: `lb.evaluate_and_add(model)` takes any
+  sklearn-compatible estimator
 
-You can use any ML library you already have installed — scikit-learn, LightGBM,
-XGBoost, PyTorch, JAX, or anything else — against a large-scale, curated data
-foundation without installing a single additional dependency.
+Your model can come from any library you already have — scikit-learn, LightGBM,
+XGBoost, PyTorch, JAX. The core install adds no heavy dependencies of its own.
 
 ### Option 2 — With all built-in models
 
@@ -64,8 +62,8 @@ all with a standard `fit(X, y)` / `predict(X)` interface:
 pip install "raman-bench[models]"
 ```
 
-This installs `torch`, `tabpfn`, `pytabkit`, `tabdpt`, `sktime`, and
-`ramanspy` on top of the core package.  **No AutoGluon required.**
+This adds `torch`, `tabpfn`, `pytabkit`, `tabdpt`, `sktime`, and `ramanspy` to
+the core package. AutoGluon is not needed for this path.
 
 ### Option 3 — Full benchmark reproducibility
 
@@ -100,17 +98,20 @@ two limitations of AutoGluon 1.5:
 
 ## RamanBench v1
 
-RamanBench's benchmark-running layer is being migrated onto
-[TabArena](https://github.com/autogluon/tabarena) (`tabarena`/`bencheval`) directly, rather
-than reimplementing patterns "inspired by" it. Concretely: each (dataset, target) pair
-becomes a TabArena `UserTask`; splitting is real repeated k-fold cross-validation
-(`raman_bench.splitting`, dataset-size-adaptive `n_repeats`, matching TabArena's own
-documented convention); each model's HPO search space is a TabArena `ConfigGenerator`
-config pool, and the default/tuned/tuned+ensemble triad is recycled from that pool with
-zero extra fitting (`EndToEnd.from_raw(...).get_results(...)`, no re-training). See
-TabArena's own docs for the underlying mechanism — RamanBench's layer on top is thin by
-design: datasets come from the raman-data HF mirror instead of OpenML, and ~13 additional
-Raman-specific model architectures are wired in alongside TabArena's own registry.
+The benchmark-running layer is being rebuilt directly on
+[TabArena](https://github.com/autogluon/tabarena) (`tabarena` / `bencheval`)
+instead of on its own reimplementation of the same ideas.
+
+Each (dataset, target) pair becomes a TabArena `UserTask`. Splitting is real
+repeated k-fold cross-validation (`raman_bench.splitting`, with `n_repeats`
+scaled to dataset size, as TabArena documents). Each model's HPO search space is
+a TabArena `ConfigGenerator` config pool, and the default / tuned /
+tuned+ensemble results are read back from that pool without any re-training
+(`EndToEnd.from_raw(...).get_results(...)`).
+
+What RamanBench adds on top is small: datasets come from the raman-data HF
+mirror rather than OpenML, and about 13 Raman-specific architectures are
+registered alongside TabArena's own models.
 
 ```bash
 git clone https://github.com/ml-lab-htw/RamanBench.git
@@ -129,8 +130,8 @@ Key entry points:
 - `cluster/` — cluster-agnostic SLURM job submission (`submit_job.py`,
   `run_experiment.sbatch`, `detect_cluster.py`, `janitor.py`) driven by a profile YAML;
   works locally too when no cluster is available.
-- `.claude/agents/` — six Claude Code agents for routine maintenance (see
-  **Contributor Agents** below).
+- `.claude/agents/` — Claude Code agents for routine maintenance, spread across
+  this repo and its siblings (see **Contributor Agents** below).
 
 New models are onboarded via a per-model directory —
 `raman_bench/models/custom/<key>/{model.py,hpo.py,info.py}`, auto-discovered into the
@@ -197,8 +198,8 @@ print(ds.targets.shape)      # (n_samples,)
 print(ds.raman_shifts[:5])   # wavenumber axis in cm⁻¹
 ```
 
-All 74 datasets are available this way.  Each comes with a fixed train/test
-split so results are directly comparable to the precomputed baselines.
+Every dataset loads this way, each with the same fixed train/test split the
+precomputed baselines used.
 
 ### Evaluate your model against 28 baselines (Option 1)
 
@@ -218,9 +219,6 @@ results = lb.evaluate_and_add(
 print(lb.rank())
 lb.plot()
 ```
-
-Bring any library — LightGBM, XGBoost, a PyTorch model, a JAX model — and it
-will be scored on the same protocol as the 28 precomputed baselines.
 
 ### Explore the precomputed leaderboard (Option 1)
 
@@ -254,7 +252,7 @@ tfm.fit(X, y)
 predictions = tfm.predict(X)
 ```
 
-### Run the full benchmark pipeline (fork required)
+### Run the full v0 benchmark pipeline
 
 ```bash
 # Pre-cache all dataset splits (optional, speeds up the run)
@@ -274,8 +272,10 @@ raman-bench run --config configs/benchmark_v0.1.json --step metrics
 |---|---|
 | [`01_quick_start.ipynb`](notebooks/01_quick_start.ipynb) | Load a dataset, explore the precomputed leaderboard, plot rankings |
 | [`02_benchmark_new_model.ipynb`](notebooks/02_benchmark_new_model.ipynb) | Evaluate your own model and add it to the leaderboard |
-| [`03_explore_results.ipynb`](notebooks/03_explore_results.ipynb) | Deep dive into per-dataset and per-domain results |
-| [`04_contribute_dataset.ipynb`](notebooks/04_contribute_dataset.ipynb) | Step-by-step guide to contributing a new dataset |
+| [`03_explore_results.ipynb`](notebooks/03_explore_results.ipynb) | Per-dataset and per-domain results |
+| [`04_contribute_dataset.ipynb`](notebooks/04_contribute_dataset.ipynb) | Adding a new dataset, step by step |
+| [`05_reproduce_benchmark.ipynb`](notebooks/05_reproduce_benchmark.ipynb) | Re-running the v0 benchmark from configs |
+| [`06_hpo_ensemble_ablation.ipynb`](notebooks/06_hpo_ensemble_ablation.ipynb) | HPO and ensembling ablation |
 
 ---
 
@@ -284,8 +284,6 @@ raman-bench run --config configs/benchmark_v0.1.json --step metrics
 ### Paper baselines (28 models)
 
 All results in the paper were produced through the AutoGluon pipeline (Option 3 install).
-
-| Category | Models |
 
 | Category | Models |
 |---|---|
@@ -303,7 +301,7 @@ All results in the paper were produced through the AutoGluon pipeline (Option 3 
 for many of the same algorithm families, usable directly without AutoGluon or
 the fork.  These are **not** the exact pipeline configurations from the paper
 (no AutoGluon preprocessing or HPO), but they use the same underlying
-algorithms and are well-suited for building and evaluating new models.
+algorithms, and are a convenient starting point for building a new model.
 
 | Class | Algorithm | Requires |
 |---|---|---|
@@ -332,16 +330,13 @@ All classes support classification and regression and auto-detect the task from
 
 ### Datasets
 
-74 public Raman spectroscopy datasets from four application domains:
+The 74 datasets span four application domains (Material Science, Biological,
+Medical, Chemical) and both task types. They range from a few dozen spectra to
+over 100,000, and from roughly 100 to 12,000 wavenumber points. The
+[raman-data catalog](https://github.com/ml-lab-htw/raman_data) lists every one
+with its source, task, size, and license.
 
-| Domain | Datasets | Task | Sources |
-|---|---|---|---|
-| Chemical | 37 | Regression | Zenodo, HuggingFace |
-| Medical | 11 | Classification | Kaggle, Zenodo |
-| Biological | 8 | Regression | HuggingFace, Zenodo |
-| Material Science | 4 | Classification | RRUFF, Zenodo |
-
-All datasets are accessible via `pip install raman-data`:
+All datasets load via `pip install raman-data`:
 
 ```python
 from raman_data import raman_data
@@ -358,7 +353,7 @@ w = dataset.raman_shifts     # wavenumber axis in cm⁻¹
 
 ## Ranking Protocol
 
-Models are evaluated under three complementary metrics:
+Models are ranked on four metrics:
 
 | Metric | Description |
 |---|---|
@@ -414,10 +409,10 @@ RamanBench/
 └── tests/                      # pytest test suite
 ```
 
-### Architecture: two paths, one set of model classes
+### How the two paths share model code
 
-Custom models are implemented once as plain scikit-learn `BaseEstimator`
-subclasses.  The same classes are used in both usage modes:
+Custom models are written once as plain scikit-learn `BaseEstimator`
+subclasses, and the same classes serve both usage modes:
 
 ```
   Custom model (e.g. DeepCNNModel)
@@ -432,28 +427,27 @@ subclasses.  The same classes are used in both usage modes:
                Prep_DEEPCNN(_RamanDLBase, _DeepCNNBridge)
 ```
 
-`SklearnAutoGluonBridge` (in `preprocessing/wrapped_models.py`) is the only
-file that imports AutoGluon.  All model source files are AutoGluon-free.
+`SklearnAutoGluonBridge` (in `preprocessing/wrapped_models.py`) is the only file
+that imports AutoGluon; the model source files never do.
 
 ---
 
 ## Contributing
 
-We welcome contributions of new models and datasets!
+New models and datasets are welcome.
 
 ### Adding a New Model
 
-The easiest way to add a model:
+Open this repo in Claude Code and say:
 
 ```
 Add my model to RamanBench, test it, and run it across the benchmark.
 ```
 
-Open this repo in Claude Code, say that, and the `model-agent` takes it from there —
-implements it (or wires up an existing TabArena model if one already fits), tests it
-locally, asks whether it should also be proposed upstream to TabArena, and runs it
-across the benchmark (cluster or local). See `.claude/agents/model-agent.md` for the
-full workflow.
+The `model-agent` implements it (or wires up an existing TabArena model if one
+already fits), tests it locally, asks whether to propose it upstream to
+TabArena, and runs it across the benchmark on a cluster or locally.
+`.claude/agents/model-agent.md` has the full workflow.
 
 <details>
 <summary>Manual steps (no agent)</summary>
@@ -517,16 +511,15 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
 
 ### Adding a New Dataset
 
-The easiest way to add a dataset:
+Same idea, in Claude Code:
 
 ```
 Add my dataset to RamanBench and make it benchmarkable.
 ```
 
-Open this repo in Claude Code, say that, and the `dataset-agent` takes it from
-there — bootstraps a `raman_data` checkout if needed, picks the right loader, syncs
-the dataset to the HF mirror the benchmark reads from, and opens a `raman_data` PR
-for completeness. See `.claude/agents/dataset-agent.md` for the full workflow.
+The `dataset-agent` bootstraps a `raman_data` checkout if needed, picks the right
+loader, syncs the dataset to the HF mirror the benchmark reads from, and opens a
+`raman_data` PR. See `.claude/agents/dataset-agent.md` for the full workflow.
 
 <details>
 <summary>Manual steps (no agent)</summary>
@@ -543,8 +536,9 @@ through `run_experiment.py`'s mirror-first loading.
 
 ## Contributor Agents
 
-Six Claude Code agents cover routine maintenance so contributors don't need any private
-tooling. Each is a `.claude/agents/*.md` file in the repo it operates on:
+Six Claude Code agents handle routine maintenance across the three repos, so a
+contributor doesn't need any private tooling. Each is a `.claude/agents/*.md`
+file in the repo it works on:
 
 | Agent | Repo | Responsibility |
 |---|---|---|
@@ -555,19 +549,12 @@ tooling. Each is a `.claude/agents/*.md` file in the repo it operates on:
 | `hf-frontend-agent` | `HF_spaces/RamanBench` | Frontend work on the public Gradio leaderboard Space. |
 | `docs-agent` | `raman_bench_paper` (cross-repo aware) | Keeps README/CONTRIBUTING in sync across all repos as things change. |
 
-Typical handoff: dataset-agent → model-agent (optional) → cluster-agent → leaderboard-agent
-(with explicit permission before publishing) → hf-frontend-agent. docs-agent runs
-independently after structural changes. None of these agents ever add a Claude/Anthropic
-co-author trailer to a commit.
-
-Quick summary:
-1. Upload your dataset to HuggingFace Datasets or Zenodo under CC BY 4.0.
-2. Add a loader to the [raman-data](https://github.com/ml-lab-htw/raman_data)
-   package (open a PR there).
-3. Open an issue here linking to the raman-data PR.
+A typical handoff runs dataset-agent → model-agent (optional) → cluster-agent →
+leaderboard-agent (which asks before publishing) → hf-frontend-agent. docs-agent
+runs on its own after structural changes.
 
 The [live leaderboard](https://huggingface.co/spaces/HTW-KI-Werkstatt/RamanBench)
-also has a "How to Contribute" section with step-by-step instructions.
+has its own "How to Contribute" section.
 
 ---
 
@@ -586,11 +573,9 @@ If you use RamanBench in your research, please cite:
 
 ---
 
-## ⭐ Star History
+## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ml-lab-htw/RamanBench&type=Date&...)](
-https://star-history.com/#ml-lab-htw/RamanBench&Date
-)
+[![Star History Chart](https://api.star-history.com/svg?repos=ml-lab-htw/RamanBench&type=Date)](https://star-history.com/#ml-lab-htw/RamanBench&Date)
 
 ---
 


### PR DESCRIPTION
## What

The README read as machine-drafted, mostly from structure rather than vocabulary (no delve/robust/seamless). This rewrites the prose-heavy parts and fixes a batch of facts that had drifted from the code.

### Prose

| Pattern | Where | Fix |
|---|---|---|
| Em-dash aside in nearly every paragraph | throughout | commas, parentheses, or split sentences |
| Mirrored scaffolding: "The easiest way to add a X:" | Contributing (model + dataset) | varied the two openers |
| Refrain: "Bring any library — LightGBM, XGBoost, ..." | L54 and L222, near-verbatim | kept one |
| "This gives you:" + bold-lead-in benefit bullets | Installation Option 1 | plain "this is enough to:" list |
| Emphatic fragments: **No AutoGluon required.** / **No fork needed.** | x4 | folded into sentences |
| Dot-separated metric blockquote, 🏆/⭐ emoji headings | header, Star History | removed |
| Defensive meta: "None of these agents ever add a co-author trailer" | Contributor Agents | deleted (not user-facing, and not true of the log) |
| Balanced-antithesis heading "Architecture: two paths, one set of classes" | Repo Structure | "How the two paths share model code" |
| "large-scale, curated data foundation" | Option 1 | cut |

### Facts fixed against the shipped code/data

- **duplicated `| Category | Models |` table header** in `## Models`
- **"three complementary metrics"** — the table has four (Elo, Score, Avg Rank, Improvability)
- **Quick Start "(fork required)"** — the fork was dropped everywhere else in the README; retitled "Run the full v0 benchmark pipeline"
- **Notebooks table** listed 4; the repo has 6 — added `05_reproduce_benchmark`, `06_hpo_ensemble_ablation`
- **broken star-history badge URL** (trailing `&...` made the image 404)
- **"six agents ... in the repo"** — they live across the three repos; the table already shows that, so reworded the lead-in
- **Benchmark Composition domain table** summed to 60 (not 74) and labelled each domain with a single task type — neither is correct. Replaced with a short paragraph + a pointer to the raman-data catalog, since I could not verify a corrected per-domain split.
- **CONTRIBUTING.md**: dropped the "Thank you for your interest" opener; fixed a Live Leaderboard row whose link text (`ml-lab-htw/RamanBench`) and href (`HTW-KI-Werkstatt/...`) disagreed.

### Left alone

The "What's changed since v0.1" changelog, the Option 3 fork explanation, the repo-structure tree, all code blocks.

## Needs a maintainer decision

The headline dataset count is **74**, but the bundled `src/raman_bench/data/precomputed/datasets.csv` has **77** rows and `configs/v1/README.md` refers to a curated **~66**. I left the prose at 74. Someone who knows which is canonical should reconcile it (and ideally teach `scripts/generate_readme_datasets.py` / whatever generates the count to keep it in sync). Same for targets: 163 in the README vs 156 in `configs/v1/README.md`.

Also out of scope: `src/raman_bench/__init__.py` `__version__` is `0.1.0` while `pyproject.toml` is `0.1.1` — a code fix, not a README one.