### PR TITLE
Support source-defined MSC fitting regions

### DIFF
--- a/src/raman_bench/preprocessing/mixin.py
+++ b/src/raman_bench/preprocessing/mixin.py
@@ -194,6 +194,13 @@ _PREP_STEP_DEFINITIONS = {
         },
         "defaults": {
             "prep_msc_enabled": False,
+            # Region used only to fit each spectrum's slope/intercept against
+            # the training-reference spectrum. The correction is still
+            # applied to the complete spectrum. Fractions are resolved from
+            # a source-verified physical Raman-shift interval by the calling
+            # experiment config; full-spectrum MSC remains the default.
+            "prep_msc_start_frac": 0.0,
+            "prep_msc_end_frac": 1.0,
         },
     },
     "emsc": {
@@ -536,13 +543,19 @@ class RamanPreprocessingMixin:
             X = rubberband_correction(X)
 
         if params.get("prep_msc_enabled", False):
-            logger.debug("Fit — MSC: fitting reference spectrum and transforming")
+            start_frac = params.get("prep_msc_start_frac", 0.0)
+            end_frac = params.get("prep_msc_end_frac", 1.0)
+            logger.debug(
+                "Fit — MSC: fitting reference spectrum and transforming, region=[%s, %s]",
+                start_frac,
+                end_frac,
+            )
             self._msc_reference = multiplicative_scatter_correction_fit(X)
             X = multiplicative_scatter_correction_transform(
                 X,
                 self._msc_reference,
-                start=0.0,
-                end=1.0,
+                start=start_frac,
+                end=end_frac,
             )
 
         if params.get("prep_emsc_enabled", False):
@@ -736,12 +749,18 @@ class RamanPreprocessingMixin:
             X = rubberband_correction(X)
 
         if params.get("prep_msc_enabled", False) and hasattr(self, "_msc_reference"):
-            logger.debug("Transform — MSC: applying transform with fitted reference spectrum")
+            start_frac = params.get("prep_msc_start_frac", 0.0)
+            end_frac = params.get("prep_msc_end_frac", 1.0)
+            logger.debug(
+                "Transform — MSC: applying fitted reference with region=[%s, %s]",
+                start_frac,
+                end_frac,
+            )
             X = multiplicative_scatter_correction_transform(
                 X,
                 self._msc_reference,
-                start=0.0,
-                end=1.0,
+                start=start_frac,
+                end=end_frac,
             )
 
         if params.get("prep_emsc_enabled", False) and hasattr(self, "_emsc_reference"):

--- a/tests/test_preprocessing_msc_region.py
+++ b/tests/test_preprocessing_msc_region.py
@@ -1,0 +1,39 @@
+"""Regression tests for source-defined MSC fitting regions."""
+
+import numpy as np
+
+from raman_bench.preprocessing import mixin
+
+
+def test_msc_region_params_are_used_consistently_for_fit_and_transform(monkeypatch):
+    calls = []
+
+    def fake_fit(X):
+        return X.mean(axis=0)
+
+    def fake_transform(X, reference, start=0.0, end=1.0):
+        calls.append((start, end, X.shape))
+        return X.copy()
+
+    monkeypatch.setattr(mixin, "multiplicative_scatter_correction_fit", fake_fit)
+    monkeypatch.setattr(mixin, "multiplicative_scatter_correction_transform", fake_transform)
+
+    class Dummy(mixin.RamanPreprocessingMixin):
+        def _get_model_params(self):
+            return {
+                "prep_msc_enabled": True,
+                "prep_msc_start_frac": 0.25,
+                "prep_msc_end_frac": 0.5,
+            }
+
+    dummy = Dummy.__new__(Dummy)
+    dummy._preprocess_fit(np.arange(24, dtype=float).reshape(4, 6))
+    dummy._preprocess_transform(np.arange(12, dtype=float).reshape(2, 6))
+
+    assert calls == [(0.25, 0.5, (4, 6)), (0.25, 0.5, (2, 6))]
+
+
+def test_msc_region_defaults_preserve_full_spectrum_behavior():
+    defaults = mixin._PREP_STEP_DEFINITIONS["msc"]["defaults"]
+    assert defaults["prep_msc_start_frac"] == 0.0
+    assert defaults["prep_msc_end_frac"] == 1.0

--- a/tests/test_preprocessing_msc_region.py
+++ b/tests/test_preprocessing_msc_region.py
@@ -1,8 +1,11 @@
 """Regression tests for source-defined MSC fitting regions."""
 
 import numpy as np
+import pytest
 
-from raman_bench.preprocessing import mixin
+pytest.importorskip("autogluon")
+
+from raman_bench.preprocessing import mixin  # noqa: E402
 
 
 def test_msc_region_params_are_used_consistently_for_fit_and_transform(monkeypatch):

--- a/tests/test_preprocessing_params.py
+++ b/tests/test_preprocessing_params.py
@@ -59,6 +59,17 @@ def test_normalize_preprocessing_params_valid():
     assert out["preprocessing_params"] == {"prep_deriv_order": 2, "prep_deriv_wl": 15}
 
 
+def test_normalize_preprocessing_params_accepts_msc_fit_region():
+    config = {
+        "preprocessing_params": {
+            "prep_msc_start_frac": 0.25,
+            "prep_msc_end_frac": 0.5,
+        }
+    }
+    out = _normalize_preprocessing_params(config)
+    assert out["preprocessing_params"] == config["preprocessing_params"]
+
+
 def test_normalize_preprocessing_params_rejects_typo():
     config = {"preprocessing_params": {"prep_derivv_order": 2}}
     with pytest.raises(ValueError, match="Unknown preprocessing_params"):


### PR DESCRIPTION
Adds configurable MSC coefficient-fitting bounds while preserving full-spectrum defaults. Includes focused fit/transform and config-normalization tests. Required by the source-verified Lange 1500–2000 cm⁻¹ ablation in RamanPreprocessing. Cluster validation: 11 focused tests passed.