### PR TITLE
Switch [benchmark] extra from git URLs to PyPI releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `[benchmark]` extra now pins real PyPI releases (`bencheval>=0.1.0`,
+  `tabarena>=0.1.0`) instead of git URLs, now that both packages publish to
+  PyPI (github.com/autogluon/tabarena/issues/495).
+
 ### Changed
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,10 +71,10 @@ autogluon = [
 ]
 benchmark = [
     # TabArena/bencheval dependencies for full benchmark orchestration.
-    # These have git-based dependencies that PyPI doesn't accept, so they're
-    # isolated in a separate extra. Cluster users install with `pip install -e .[cluster]`.
-    "bencheval @ git+https://github.com/autogluon/tabarena.git#subdirectory=packages/bencheval",
-    "tabarena @ git+https://github.com/autogluon/tabarena.git#subdirectory=packages/tabarena",
+    # As of their PyPI prerelease (see github.com/autogluon/tabarena/issues/495),
+    # both install as real PyPI packages -- no git URLs needed anymore.
+    "bencheval>=0.1.0",
+    "tabarena>=0.1.0",
 ]
 models = [
     "raman-bench[autogluon]",


### PR DESCRIPTION
tabarena/bencheval now publish real PyPI releases (`0.1.0`), following github.com/autogluon/tabarena/issues/495. The `[benchmark]` extra no longer needs the git-URL workaround — swapped to `bencheval>=0.1.0` / `tabarena>=0.1.0`.

Verified in a clean venv: `pip install -e .[benchmark]` resolves and imports cleanly, no `--pre` needed.