### PR TITLE
models extra: use PyPI tabarena>=0.1.0 instead of the git URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,12 +90,13 @@ models = [
     # permissive tabpfn/tabpfn-extensions floor below instead, which tabpfnwide's
     # exact pin already satisfies.
     #
-    # The extras MUST be attached directly to this git URL, not requested as a bare
-    # "tabarena[...]" elsewhere -- a real (unrelated, version-0.0.0 placeholder)
-    # package named "tabarena" exists on PyPI, so a bare name+extras requirement
-    # resolves against *that* instead of this git dependency and conflicts with the
-    # `benchmark` extra's URL-pinned "tabarena" (confirmed via a real pip
-    # resolve: ResolutionImpossible over exactly this).
+    # These extras used to be attached to a git URL (git+https://github.com/autogluon/
+    # tabarena.git#subdirectory=packages/tabarena) because the only "tabarena" on PyPI
+    # was an unrelated version-0.0.0 placeholder, so a bare "tabarena[...]" requirement
+    # resolved against that and conflicted with the `benchmark` extra. TabArena
+    # published the real `tabarena` 0.1.0 to PyPI on 2026-09-03 (it declares all the
+    # per-model extras used here), so this is now a plain versioned PyPI requirement,
+    # matching `benchmark`'s `tabarena>=0.1.0`.
     # perpetualboosting/chimeraboost (batch 2 of the TabArena-native onboarding) pull
     # in their own third-party package below TabArena's own `pip_extra` metadata
     # (perpetual, chimeraboost>=0.14.1 respectively -- see
@@ -109,7 +110,7 @@ models = [
     # the package's own documented CPU-safe "General Installation" path -- the
     # `cu12`/`cu11` extras are opt-in GPU-kernel acceleration only, and XRFM already
     # runs fine without them (falls back to `device="cpu"`, see generate/xrfm.py).
-    "tabarena[tabicl,ebm,search_spaces,realmlp,tabdpt,tabm,perpetualboosting,chimeraboost] @ git+https://github.com/autogluon/tabarena.git#subdirectory=packages/tabarena",
+    "tabarena[tabicl,ebm,search_spaces,realmlp,tabdpt,tabm,perpetualboosting,chimeraboost]>=0.1.0",
     "xrfm",
     "ramanspy>=0.2.10,<0.3.0",
     "imodels>=2.0.4",


### PR DESCRIPTION
TabArena published the real `tabarena` **0.1.0** to PyPI on **2026-09-03** (declaring every per-model extra RamanBench uses: `tabicl`, `ebm`, `realmlp`, `tabdpt`, `tabm`, `perpetualboosting`, `chimeraboost`, `search-spaces`). Before that, the only PyPI `tabarena` was a `0.0.0` placeholder, which is why `[models]` pulled it from a git URL.

## Change

`[models]`:
```
- "tabarena[...] @ git+https://github.com/autogluon/tabarena.git#subdirectory=packages/tabarena"
+ "tabarena[tabicl,ebm,search_spaces,realmlp,tabdpt,tabm,perpetualboosting,chimeraboost]>=0.1.0"
```
Now matches `[benchmark]`'s `tabarena>=0.1.0`. Comment block updated.

## Resolve test (linux, cluster `prep_effects` env, `pip install --dry-run --ignore-installed`)

Isolated resolve of the touched scope — `tabarena[...]>=0.1.0` + `bencheval>=0.1.0` + `autogluon.{core,tabular}` + `tabpfn`/`tabpfnwide`/`tabpfn-extensions` + `sktime` + `imodels` + `xrfm` + `category_encoders` — **resolves cleanly, 166 packages, exit 0**:

| pkg | version | source |
|---|---|---|
| tabarena | 0.1.0 | **pypi** |
| bencheval | 0.1.0 | pypi |
| tabicl / tabdpt / tabm | 2.2.0 / 1.3.0 / 0.0.3 | pypi |
| pytabkit (realmlp) | 1.7.3 | pypi |
| perpetual / chimeraboost | 2.1.0 / 0.32.0 | pypi |
| tabpfn / tabpfnwide / tabpfn-extensions | 8.0.3 / 0.3.0 / 0.4.2 | pypi |

The old `tabpfnwide` vs `tabarena[tabpfn]` `ResolutionImpossible` doesn't apply — `[models]` uses `[tabicl,...]` (not `[tabpfn]`), and current `tabpfnwide 0.3.0` is compatible with `tabpfn 8.x`.

**Note:** a full clean-slate `pip install --dry-run '.[models]'` still fails `ResolutionImpossible` over the batch-3 **git** deps (`sap_rpt_oss`, `tabfm`, `tabtune`) — but that is **identical on `main` without this change** (verified against `origin/main`), a pre-existing property of those pinned git deps not co-resolving from scratch (the real env is built incrementally, per the pyproject comments). Not introduced or affected here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmH8BrBKJ5rirnqQQN9iEG