### PR TITLE
Release 1.1.1: make the package PyPI-publishable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,19 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [1.1.0] — 2026-09-10
+## [1.1.1] — 2026-09-10
+
+### Fixed
+
+- **PyPI publishing.** `pip install raman-bench` (and every extra) was rejected on
+  upload with `400 Can't have direct dependency` because the `[models]` extra carried
+  three `@ git+https://…` requirements (`tabfm`, `sap_rpt_oss`, `tabtune`). PyPI
+  forbids direct-URL requirements in an uploaded package. Those three are moved out of
+  `pyproject.toml` into `requirements-models-git.txt` (`pip install -r
+  requirements-models-git.txt`). No PyPI-installable model is affected; `Prep_TABFM`,
+  `Prep_SAP_RPT_OSS` and `Prep_ORIONMSP` degrade to the existing "not available" guard
+  until the git requirements file is installed. 1.1.0 was tagged and released on
+  GitHub but never reached PyPI for this reason.
 
 Pipeline B (real repeated k-fold) preprocessing-ablation support, three new
 chemometric baseline models, and a fix for a 100%-failure bug on the

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ pip install "raman-bench[models]"
 This adds `torch`, `tabpfn`, `pytabkit`, `tabdpt`, `sktime`, and `ramanspy` to
 the core package. AutoGluon is not needed for this path.
 
+Three wrapped models — `Prep_TABFM`, `Prep_SAP_RPT_OSS`, `Prep_ORIONMSP` — have
+git-only upstreams and cannot ship in a PyPI package. Install them separately if
+you need them:
+
+```bash
+pip install -r requirements-models-git.txt
+```
+
+Until then those three classes raise a clear "not available" error; every other
+model works without this step.
+
 ### Option 3 — Full benchmark reproducibility
 
 The paper's benchmark runs all models through AutoGluon's automated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "raman-bench"
-version = "1.1.0"
+version = "1.1.1"
 description = "A large-scale benchmark for machine learning on Raman spectroscopy data"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -123,14 +123,10 @@ models = [
     # unconditionally at module level, so it's a hard runtime dependency of any ModernNCA
     # fit, not an optional/rarely-hit one (matches tabarena's own modernnca_info.pip_extra).
     "category_encoders",
-    # TabFM (Prep_TABFM) -- pinned to the exact commit tabarena's own tabfm_info.pip_extra
-    # uses, so the estimator this wraps stays the one tabarena's search space was tuned
-    # against.
-    "tabfm[pytorch] @ git+https://github.com/google-research/tabfm.git@633cd265f498e1d20c9625be0639f6305d8e2541",
     # Batch 3 (NORI, SAP_RPT_OSS, ORIONMSP, ILTM, LIMIX, TABSTAR) -- the final batch
-    # of the TabArena-native onboarding effort. Every pin below matches tabarena's
+    # of the TabArena-native onboarding effort. Every PyPI pin below matches tabarena's
     # own pip_extra metadata (tabarena.models.<key>.info) exactly, same rationale as
-    # perpetualboosting/chimeraboost/xrfm/tabfm above: these estimators stay the same
+    # perpetualboosting/chimeraboost/xrfm above: these estimators stay the same
     # ones tabarena's own search spaces were tuned against.
     #
     # NOTE: iLTM's own floor (`numpy>=2.3.3`) forces a NumPy 1.x -> 2.x bump in this
@@ -139,12 +135,18 @@ models = [
     # satisfying both iLTM's floor and sktime's own `numpy<2.4,>=1.21` ceiling
     # simultaneously; the full suite passed, no other model regressed).
     "synthefy-nori>=0.7.0",
-    "sap_rpt_oss @ git+https://github.com/SAP-samples/sap-rpt-1-oss.git@a323a0aff976fda4ac43c3196a92406de7689aaa",
-    "tabtune @ git+https://github.com/Lexsi-Labs/TabTune.git",
     "iltm>=0.1.1",
     "einops",
     "kditransform",
     "tabstar==1.1.15",
+    # NOTE: three TabArena-native models -- TabFM (Prep_TABFM), SAP-RPT-OSS
+    # (Prep_SAP_RPT_OSS) and OrionMSP (Prep_ORIONMSP, from the `tabtune` package) --
+    # are NOT installable from here. Their upstream packages publish no PyPI release,
+    # only git repos, and PyPI forbids direct-URL (`@ git+https://...`) requirements
+    # in an uploaded package. Install them by hand from `requirements-models-git.txt`
+    # (`pip install -r requirements-models-git.txt`); the corresponding Prep_* classes
+    # degrade to a clear "not available" error until you do (see
+    # preprocessing/wrapped_models.py's optional-import guard).
 ]
 full = [
     "raman-bench[autogluon]",

--- a/requirements-models-git.txt
+++ b/requirements-models-git.txt
@@ -1,0 +1,23 @@
+# Git-only model dependencies -- NOT installable via `pip install raman-bench[models]`.
+#
+# These three TabArena-native models are wrapped by RamanBench (Prep_TABFM,
+# Prep_SAP_RPT_OSS, Prep_ORIONMSP) but their upstream packages publish no PyPI
+# release, only a git repo. PyPI forbids direct-URL requirements in an uploaded
+# package, so they cannot live in pyproject.toml's `[models]` extra.
+#
+# Install after `pip install raman-bench[models]` (or `[full]`):
+#     pip install -r requirements-models-git.txt
+#
+# Each pin matches tabarena's own pip_extra metadata (tabarena.models.<key>.info)
+# so the wrapped estimator stays the one tabarena's search space was tuned against.
+# Until installed, the corresponding Prep_* classes raise a clear "not available"
+# error (see src/raman_bench/preprocessing/wrapped_models.py).
+
+# TabFM  -> Prep_TABFM   (tabarena.models.tabfm.model.TabFMModel)
+tabfm[pytorch] @ git+https://github.com/google-research/tabfm.git@633cd265f498e1d20c9625be0639f6305d8e2541
+
+# SAP-RPT-OSS  -> Prep_SAP_RPT_OSS   (tabarena.models.sap_rpt_oss.model.SAPRPTOSSModel)
+sap_rpt_oss @ git+https://github.com/SAP-samples/sap-rpt-1-oss.git@a323a0aff976fda4ac43c3196a92406de7689aaa
+
+# OrionMSP  -> Prep_ORIONMSP   (tabarena.models.orionmsp.model.OrionMSPModel, from the tabtune package)
+tabtune @ git+https://github.com/Lexsi-Labs/TabTune.git

--- a/src/raman_bench/__init__.py
+++ b/src/raman_bench/__init__.py
@@ -48,7 +48,7 @@ from dotenv import load_dotenv
 load_dotenv(Path(__file__).resolve().parents[2] / ".env")
 load_dotenv()
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __author__ = "Mario Koddenbrock (HTW Berlin), Christoph Lange (TU Berlin)"
 
 _public_map = {


### PR DESCRIPTION
## Why

`v1.1.0` was tagged and a GitHub Release created, but **Publish to PyPI failed**:

```
400 Can't have direct dependency: tabfm[pytorch] @ git+https://github.com/google-research/tabfm.git@...
```

PyPI forbids direct-URL (`@ git+https://…`) requirements in an uploaded distribution.
The `[models]` extra carried three: `tabfm`, `sap_rpt_oss`, `tabtune`. Their
upstreams publish no PyPI release, so they can't be version-pinned either.

## Change

- Move the three git-only requirements into **`requirements-models-git.txt`**
  (`pip install -r requirements-models-git.txt`). Pins unchanged — still match
  `tabarena.models.<key>.info`'s `pip_extra`.
- `Prep_TABFM` / `Prep_SAP_RPT_OSS` / `Prep_ORIONMSP` fall back to the existing
  optional-import "not available" guard in `wrapped_models.py` until that file is
  installed. No PyPI-installable model is affected.
- README install note; version `1.1.0` → `1.1.1` (`pyproject` + `__init__`); CHANGELOG.

## Verification

- `python -m build` + `twine check dist/*` both pass.
- Built wheel `METADATA` has **no** direct-URL `Requires-Dist`.

After merge: tag `v1.1.1`, create the Release, the Publish to PyPI workflow
(trusted publisher now configured) should upload cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmH8BrBKJ5rirnqQQN9iEG